### PR TITLE
Disabled UseLocalHostAsDefaultHost feature gate for otel collector

### DIFF
--- a/cli/service/resources/infra.yaml
+++ b/cli/service/resources/infra.yaml
@@ -233,6 +233,9 @@ spec:
         command:
           - "/otelcontribcol"
           - "--config=/conf/otel-collector-config.yaml"
+          - "--feature-gates=-component.UseLocalHostAsDefaultHost" 
+            # https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.104.0
+            # Need to disable this feature gate so that the otlpreceiver uses 0.0.0.0 instead of localhost
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
`v0.104.0` version introduced a breaking change in k8s, and required us to disable a feature gate to get our otel collector running