### PR TITLE
Initial partitioned queries

### DIFF
--- a/control-planes/mgmt_api/src/api/v1/mappings.rs
+++ b/control-planes/mgmt_api/src/api/v1/mappings.rs
@@ -1,8 +1,8 @@
 use super::models::*;
 use crate::domain::models::{
     ConfigValue, Endpoint, EndpointSetting, InlineValue, QueryContainerSpec, QueryContainerStatus,
-    QueryJoin, QueryJoinKey, QuerySourceLabel, QuerySources, QuerySpec, QueryStatus,
-    QuerySubscription, ReactionProviderSpec, ReactionSpec, ReactionStatus, Resource,
+    QueryJoin, QueryJoinKey, QueryPartitionStatus, QuerySourceLabel, QuerySources, QuerySpec,
+    QueryStatus, QuerySubscription, ReactionProviderSpec, ReactionSpec, ReactionStatus, Resource,
     ResourceProvider, RetentionPolicy, Service, SourceMiddlewareConfig, SourceProviderSpec,
     SourceSpec, SourceStatus, StorageSpec, ViewSpec,
 };
@@ -42,6 +42,15 @@ impl From<ReactionStatus> for ReactionStatusDto {
 impl From<QueryStatus> for QueryStatusDto {
     fn from(status: QueryStatus) -> Self {
         QueryStatusDto {
+            partitions: status.partitions.into_iter().map(|v| v.into()).collect(),
+        }
+    }
+}
+
+impl From<QueryPartitionStatus> for QueryPartitionStatusDto {
+    fn from(status: QueryPartitionStatus) -> Self {
+        QueryPartitionStatusDto {
+            partition: status.partition,
             host_name: status.host_name,
             status: status.status,
             container: status.container,
@@ -537,6 +546,7 @@ impl Into<QuerySpec> for QuerySpecDto {
             sources: self.sources.into(),
             storage_profile: self.storage_profile,
             view: self.view.unwrap_or_default().into(),
+            partition_count: self.partition_count,
         }
     }
 }
@@ -550,6 +560,7 @@ impl From<QuerySpec> for QuerySpecDto {
             sources: spec.sources.into(),
             storage_profile: spec.storage_profile,
             view: Some(spec.view.into()),
+            partition_count: spec.partition_count,
         }
     }
 }
@@ -645,6 +656,7 @@ impl Into<QuerySourceLabel> for QuerySourceLabelDto {
     fn into(self) -> QuerySourceLabel {
         QuerySourceLabel {
             source_label: self.source_label,
+            partition_key: self.partition_key,
         }
     }
 }
@@ -653,6 +665,7 @@ impl From<QuerySourceLabel> for QuerySourceLabelDto {
     fn from(label: QuerySourceLabel) -> Self {
         QuerySourceLabelDto {
             source_label: label.source_label,
+            partition_key: label.partition_key,
         }
     }
 }

--- a/control-planes/mgmt_api/src/api/v1/models.rs
+++ b/control-planes/mgmt_api/src/api/v1/models.rs
@@ -152,6 +152,7 @@ pub struct ReactionStatusDto {
 #[serde(rename_all = "camelCase")]
 pub struct QuerySourceLabelDto {
     pub source_label: String,
+    pub partition_key: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -187,6 +188,7 @@ pub struct QuerySpecDto {
     pub sources: QuerySourcesDto,
     pub storage_profile: Option<String>,
     pub view: Option<ViewSpecDto>,
+    pub partition_count: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -210,6 +212,13 @@ pub struct QuerySourcesDto {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryStatusDto {
+    pub partitions: Vec<QueryPartitionStatusDto>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryPartitionStatusDto {
+    pub partition: Option<u64>,
     pub host_name: String,
     pub status: String,
     pub container: String,

--- a/control-planes/mgmt_api/src/domain/debug_service.rs
+++ b/control-planes/mgmt_api/src/domain/debug_service.rs
@@ -6,7 +6,10 @@ use futures_util::{Stream, StreamExt};
 use resource_provider_api::models::QueryStatus;
 use serde_json::{Map, Value};
 
-use crate::domain::result_service::api::{ControlSignal, ResultEvent};
+use crate::domain::{
+    mappings::ToQueryPartitions,
+    result_service::api::{ControlSignal, ResultEvent},
+};
 
 use super::{
     models::{DomainError, QuerySpec},
@@ -39,7 +42,7 @@ impl DebugService {
             resource_provider_api::models::QuerySpec,
         > {
             id: temp_id.clone(),
-            spec: spec.clone().into(),
+            spec: spec.clone().into_single_partition(),
         };
 
         let _: () = match mut_dapr

--- a/control-planes/mgmt_api/src/domain/models.rs
+++ b/control-planes/mgmt_api/src/domain/models.rs
@@ -114,6 +114,7 @@ pub struct ReactionProviderStatus {
 #[serde(rename_all = "camelCase")]
 pub struct QuerySourceLabel {
     pub source_label: String,
+    pub partition_key: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -148,6 +149,7 @@ pub struct QuerySpec {
     pub sources: QuerySources,
     pub storage_profile: Option<String>,
     pub view: ViewSpec,
+    pub partition_count: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -171,6 +173,13 @@ pub struct QuerySources {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryStatus {
+    pub partitions: Vec<QueryPartitionStatus>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryPartitionStatus {
+    pub partition: Option<u64>,
     pub host_name: String,
     pub status: String,
     pub container: String,
@@ -261,5 +270,7 @@ pub enum DomainError {
     QueryContainerOffline,
 
     #[error("Internal: {inner}")]
-    Internal { inner: Box<dyn std::error::Error> },
+    Internal {
+        inner: Box<dyn std::error::Error + Send + Sync>,
+    },
 }

--- a/control-planes/mgmt_api/src/domain/resource_services/query_service.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/query_service.rs
@@ -1,23 +1,29 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 
-use super::{
-    QueryContainerDomainService, ResourceDomainService, ResourceDomainServiceImpl, SpecValidator,
-};
+use super::{QueryContainerDomainService, ResourceDomainService, SpecValidator};
+use crate::domain::models::Resource;
+use crate::ResourceSpecRepository;
 use crate::{
-    domain::models::{DomainError, QuerySpec, QueryStatus},
+    domain::{
+        mappings::ToQueryPartitions,
+        models::{DomainError, QuerySpec, QueryStatus},
+    },
     persistence::QueryRepository,
 };
 use async_trait::async_trait;
 use dapr::client::TonicClient;
+use tokio::task;
 
 pub type QueryDomainService = dyn ResourceDomainService<QuerySpec, QueryStatus>;
-pub type QueryDomainServiceImpl = ResourceDomainServiceImpl<
-    QuerySpec,
-    QueryStatus,
-    resource_provider_api::models::QuerySpec,
-    resource_provider_api::models::QueryStatus,
->;
+
+pub struct QueryDomainServiceImpl {
+    dapr_client: dapr::Client<TonicClient>,
+    repo: Box<dyn ResourceSpecRepository<QuerySpec> + Send + Sync>,
+    actor_type: fn(&QuerySpec) -> String,
+    validators: Vec<Box<dyn SpecValidator<QuerySpec> + Send + Sync>>,
+}
 
 impl QueryDomainServiceImpl {
     pub fn new(
@@ -29,17 +35,310 @@ impl QueryDomainServiceImpl {
             dapr_client,
             repo: repo,
             actor_type: |spec| format!("{}.ContinuousQuery", spec.container),
-            ready_check: |status| status.status == "RUNNING",
             validators: vec![Box::new(QuerySpecValidator {
                 query_container_service: container_service,
             })],
-            retrieve_current_kind: |_spec| None,
-            populate_default_values: |properties, _| Ok(properties.clone()),
-            _TSpec: std::marker::PhantomData,
-            _TStatus: std::marker::PhantomData,
-            _TApiSpec: std::marker::PhantomData,
-            _TApiStatus: std::marker::PhantomData,
         }
+    }
+
+    async fn collect_partition_statuses(
+        &self,
+        query_id: &str,
+        query_spec: &QuerySpec,
+    ) -> Result<Vec<resource_provider_api::models::QueryStatus>, DomainError> {
+        let partition_ids = query_spec.to_query_partition_ids(query_id);
+
+        let handles: BTreeMap<_, _> = partition_ids
+            .into_iter()
+            .map(|query_id| {
+                let mut dapr = self.dapr_client.clone();
+                let actor_type = (self.actor_type)(&query_spec);
+
+                (
+                    query_id.clone(),
+                    task::spawn(async move {
+                        let status: resource_provider_api::models::QueryStatus = match dapr
+                            .invoke_actor(
+                                actor_type.clone(),
+                                query_id.clone(),
+                                "getStatus",
+                                (),
+                                None,
+                            )
+                            .await
+                        {
+                            Ok(r) => r,
+                            Err(e) => {
+                                log::error!(
+                                    "Error getting status for query partition {query_id}: {}",
+                                    e
+                                );
+                                return Err(DomainError::Internal { inner: Box::new(e) });
+                            }
+                        };
+
+                        Ok((query_id, status))
+                    }),
+                )
+            })
+            .collect();
+
+        let mut partitions = Vec::new();
+
+        for (query_id, handle) in handles {
+            match handle.await {
+                Ok(r) => match r {
+                    Ok((query_id, status)) => {
+                        log::info!("Got status for query partition {}", query_id);
+                        partitions.push(status);
+                    }
+                    Err(e) => {
+                        log::error!("Task failed for query partition {query_id}: {}", e);
+                        return Err(DomainError::Internal { inner: Box::new(e) });
+                    }
+                },
+                Err(e) => {
+                    log::error!("Task failed for query partition {query_id}: {}", e);
+                    return Err(DomainError::Internal { inner: Box::new(e) });
+                }
+            }
+        }
+
+        Ok(partitions)
+    }
+}
+
+#[async_trait]
+impl ResourceDomainService<QuerySpec, QueryStatus> for QueryDomainServiceImpl {
+    async fn set(
+        &self,
+        id: &str,
+        query_spec: QuerySpec,
+    ) -> Result<Resource<QuerySpec, QueryStatus>, DomainError> {
+        for validator in &self.validators {
+            validator.validate(&query_spec, &None).await?;
+        }
+
+        self.repo.set(id, &query_spec).await?;
+
+        let partition_specs = query_spec.to_query_partitions(id);
+
+        let handles: BTreeMap<_, _> = partition_specs
+            .into_iter()
+            .map(|(query_id, partition_spec)| {
+                let mut dapr = self.dapr_client.clone();
+                let actor_type = (self.actor_type)(&query_spec);
+
+                let request = resource_provider_api::models::ResourceRequest::<
+                    resource_provider_api::models::QuerySpec,
+                > {
+                    id: query_id.clone(),
+                    spec: partition_spec,
+                };
+
+                (
+                    query_id.clone(),
+                    task::spawn(async move {
+                        let _: () = match dapr
+                            .invoke_actor(actor_type, query_id.clone(), "configure", request, None)
+                            .await
+                        {
+                            Err(e) => {
+                                log::error!("Error configuring query partition {query_id}: {}", e);
+                                return Err(DomainError::Internal { inner: Box::new(e) });
+                            }
+                            Ok(r) => r,
+                        };
+
+                        Ok(())
+                    }),
+                )
+            })
+            .collect();
+
+        for (query_id, handle) in handles {
+            match handle.await {
+                Ok(r) => match r {
+                    Ok(_) => log::info!("Configured query partition {}", query_id),
+                    Err(e) => {
+                        log::error!("Task failed for query partition {query_id}: {}", e);
+                        return Err(DomainError::Internal { inner: Box::new(e) });
+                    }
+                },
+                Err(e) => {
+                    log::error!("Task failed for query partition {query_id}: {}", e);
+                    return Err(DomainError::Internal { inner: Box::new(e) });
+                }
+            }
+        }
+
+        Ok(Resource {
+            id: id.to_string(),
+            spec: query_spec,
+            status: None,
+        })
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), DomainError> {
+        log::info!("Deleting query: {}", id);
+        let spec = self.repo.get(id).await?;
+        let partition_ids = spec.to_query_partition_ids(id);
+
+        let handles: BTreeMap<_, _> = partition_ids
+            .into_iter()
+            .map(|query_id| {
+                let mut dapr = self.dapr_client.clone();
+                let actor_type = (self.actor_type)(&spec);
+
+                (
+                    query_id.clone(),
+                    task::spawn(async move {
+                        let _: () = match dapr
+                            .invoke_actor(
+                                actor_type.clone(),
+                                query_id.clone(),
+                                "deprovision",
+                                (),
+                                None,
+                            )
+                            .await
+                        {
+                            Err(e) => {
+                                log::error!(
+                                    "Error deprovisioning query partition {query_id}: {}",
+                                    e
+                                );
+                                return Err(DomainError::Internal { inner: Box::new(e) });
+                            }
+                            Ok(r) => r,
+                        };
+
+                        Ok(())
+                    }),
+                )
+            })
+            .collect();
+
+        for (query_id, handle) in handles {
+            match handle.await {
+                Ok(r) => match r {
+                    Ok(_) => log::info!("Deprovisioned query partition {}", query_id),
+                    Err(e) => {
+                        log::error!("Task failed for query partition {query_id}: {}", e);
+                        return Err(DomainError::Internal { inner: Box::new(e) });
+                    }
+                },
+                Err(e) => {
+                    log::error!("Task failed for query partition {query_id}: {}", e);
+                    return Err(DomainError::Internal { inner: Box::new(e) });
+                }
+            }
+        }
+
+        self.repo.delete(id).await?;
+        Ok(())
+    }
+
+    async fn get(&self, id: &str) -> Result<Resource<QuerySpec, QueryStatus>, DomainError> {
+        log::info!("Getting query: {}", id);
+        let query_spec = self.repo.get(id).await?;
+        let statuses = self.collect_partition_statuses(id, &query_spec).await?;
+        let status_ref: &[resource_provider_api::models::QueryStatus] = &statuses;
+
+        Ok(Resource {
+            id: id.to_string(),
+            spec: query_spec,
+            status: Some(status_ref.into()),
+        })
+    }
+
+    async fn list(&self) -> Result<Vec<Resource<QuerySpec, QueryStatus>>, DomainError> {
+        log::info!("Listing queries");
+        let mut result = Vec::new();
+        let queries = self.repo.list().await;
+        for (id, query_spec) in &queries {
+            let statuses = self.collect_partition_statuses(id, &query_spec).await?;
+            let status_ref: &[resource_provider_api::models::QueryStatus] = &statuses;
+
+            result.push(Resource {
+                id: id.to_string(),
+                spec: query_spec.clone(),
+                status: Some(status_ref.into()),
+            });
+        }
+
+        Ok(result)
+    }
+
+    async fn wait_for_ready(&self, id: &str, time_out: Duration) -> Result<bool, DomainError> {
+        //todo: temp solution, will reimplement with events
+        let interval = Duration::from_secs(1);
+        let query_spec = self.repo.get(id).await?;
+        let partition_ids = query_spec.to_query_partition_ids(id);
+
+        let handles: BTreeMap<_, _> = partition_ids
+            .into_iter()
+            .map(|query_id| {
+                let mut dapr = self.dapr_client.clone();
+                let actor_type = (self.actor_type)(&query_spec);
+
+                (
+                    query_id.clone(),
+                    task::spawn(async move {
+                        let start = std::time::Instant::now();
+                        while start.elapsed() < time_out {
+                            let status: resource_provider_api::models::QueryStatus = match dapr
+                                .invoke_actor(
+                                    actor_type.clone(),
+                                    query_id.clone(),
+                                    "getStatus",
+                                    (),
+                                    None,
+                                )
+                                .await
+                            {
+                                Ok(r) => r,
+                                Err(e) => {
+                                    log::error!(
+                                        "Error getting status for query partition {query_id}: {}",
+                                        e
+                                    );
+                                    return Err(DomainError::Internal { inner: Box::new(e) });
+                                }
+                            };
+
+                            if status.status == "RUNNING" {
+                                return Ok(true);
+                            }
+
+                            tokio::time::sleep(interval).await;
+                        }
+                        Ok(false)
+                    }),
+                )
+            })
+            .collect();
+
+        for (query_id, handle) in handles {
+            match handle.await {
+                Ok(r) => match r {
+                    Ok(ready) => {
+                        if !ready {
+                            return Ok(false);
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Task failed for query partition {query_id}: {}", e);
+                        return Err(DomainError::Internal { inner: Box::new(e) });
+                    }
+                },
+                Err(e) => {
+                    log::error!("Task failed for query partition {query_id}: {}", e);
+                    return Err(DomainError::Internal { inner: Box::new(e) });
+                }
+            }
+        }
+        Ok(true)
     }
 }
 

--- a/control-planes/resource_provider_api/src/models.rs
+++ b/control-planes/resource_provider_api/src/models.rs
@@ -200,6 +200,7 @@ pub enum EndpointSetting {
 #[serde(rename_all = "camelCase")]
 pub struct QuerySourceLabel {
     pub source_label: String,
+    pub partition_key: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -249,6 +250,15 @@ pub struct QuerySpec {
     pub sources: QuerySources,
     pub storage_profile: Option<String>,
     pub view: ViewSpec,
+    pub partition: Option<QueryPartitionSpec>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryPartitionSpec {
+    pub id: u64,
+    pub count: u64,
+    pub result_stream: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -264,6 +274,7 @@ pub struct QuerySources {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryStatus {
+    pub partition: Option<u64>,
     pub host_name: String,
     pub status: String,
     pub container: String,

--- a/query-container/Cargo.lock
+++ b/query-container/Cargo.lock
@@ -32,11 +32,20 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+dependencies = [
+ "memchr 0.1.11",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
- "memchr",
+ "memchr 2.7.4",
 ]
 
 [[package]]
@@ -115,7 +124,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -194,7 +203,7 @@ dependencies = [
  "hyper",
  "itoa",
  "matchit",
- "memchr",
+ "memchr 2.7.4",
  "mime",
  "percent-encoding",
  "pin-project-lite",
@@ -289,13 +298,13 @@ dependencies = [
  "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
- "lazy_static",
+ "lazy_static 1.5.0",
  "lazycell",
  "peeking_take_while",
  "prettyplease 0.2.20",
  "proc-macro2",
  "quote",
- "regex",
+ "regex 1.10.5",
  "rustc-hash",
  "shlex",
  "syn 2.0.72",
@@ -432,7 +441,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -450,7 +459,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits",
+ "num-traits 0.2.19",
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
@@ -531,7 +540,7 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "futures-core",
- "memchr",
+ "memchr 2.7.4",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -676,8 +685,24 @@ checksum = "c2ef451feee09ae5ecd8a02e738bd9adee9266b8fa9b44e22d3ce968d8694238"
 dependencies = [
  "anyhow",
  "chrono",
- "lazy_static",
- "regex",
+ "lazy_static 1.5.0",
+ "regex 1.10.5",
+]
+
+[[package]]
+name = "datetime"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c44b6c112860e38412e0c4732172d723458d40db906ee4b9ce87544f022a7b9"
+dependencies = [
+ "iso8601",
+ "kernel32-sys",
+ "libc",
+ "locale",
+ "num-traits 0.1.43",
+ "pad",
+ "redox_syscall 0.1.57",
+ "winapi 0.2.8",
 ]
 
 [[package]]
@@ -765,13 +790,13 @@ dependencies = [
  "hashers",
  "iso8601-duration",
  "itoa",
- "lazy_static",
+ "lazy_static 1.5.0",
  "log",
  "opentelemetry",
  "ordered-float",
  "priority-queue",
  "rand 0.8.5",
- "regex",
+ "regex 1.10.5",
  "round",
  "serde",
  "serde_json",
@@ -780,6 +805,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "zoneinfo_parse",
 ]
 
 [[package]]
@@ -897,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
- "regex",
+ "regex 1.10.5",
 ]
 
 [[package]]
@@ -909,7 +935,7 @@ dependencies = [
  "humantime",
  "is-terminal",
  "log",
- "regex",
+ "regex 1.10.5",
  "termcolor",
 ]
 
@@ -1091,7 +1117,7 @@ dependencies = [
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
+ "memchr 2.7.4",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1259,7 +1285,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1457,12 +1483,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "iso8601"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11dc464f8c6f17595d191447c9c6559298b2d023d6f846a4a23ac7ea3c46c477"
+dependencies = [
+ "nom 1.2.4",
+]
+
+[[package]]
 name = "iso8601-duration"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26adff60a5d3ca10dc271ad37a34ff376595d2a1e5f21d02564929ca888c511"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1513,14 +1548,30 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
 dependencies = [
- "lazy_static",
+ "lazy_static 1.5.0",
  "once_cell",
  "pest",
  "pest_derive",
- "regex",
+ "regex 1.10.5",
  "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 
 [[package]]
 name = "lazy_static"
@@ -1588,6 +1639,15 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "locale"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdbe492a9c0238da900a1165c42fc5067161ce292678a6fe80921f30fe307fd"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lock_api"
@@ -1663,6 +1723,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
@@ -1709,7 +1778,7 @@ dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "lazy_static",
+ "lazy_static 1.5.0",
  "mockall_derive",
  "predicates",
  "predicates-tree",
@@ -1746,7 +1815,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hmac",
- "lazy_static",
+ "lazy_static 1.5.0",
  "md-5",
  "pbkdf2",
  "percent-encoding",
@@ -1799,11 +1868,17 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
+
+[[package]]
+name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "memchr",
+ "memchr 2.7.4",
  "minimal-lexical",
 ]
 
@@ -1814,7 +1889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1828,7 +1903,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1839,7 +1914,7 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg 1.3.0",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1849,7 +1924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg 1.3.0",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1864,7 +1939,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1875,7 +1950,7 @@ checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg 1.3.0",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1887,7 +1962,16 @@ dependencies = [
  "autocfg 1.3.0",
  "num-bigint",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1905,7 +1989,7 @@ version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
- "memchr",
+ "memchr 2.7.4",
 ]
 
 [[package]]
@@ -2040,7 +2124,7 @@ dependencies = [
  "ordered-float",
  "percent-encoding",
  "rand 0.8.5",
- "regex",
+ "regex 1.10.5",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2053,7 +2137,7 @@ version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -2061,6 +2145,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pad"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2080,7 +2173,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.3",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2091,7 +2184,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
- "regex",
+ "regex 1.10.5",
 ]
 
 [[package]]
@@ -2148,7 +2241,7 @@ version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
- "memchr",
+ "memchr 2.7.4",
  "thiserror",
  "ucd-trie",
 ]
@@ -2383,14 +2476,14 @@ dependencies = [
  "bytes",
  "heck",
  "itertools 0.10.5",
- "lazy_static",
+ "lazy_static 1.5.0",
  "log",
  "multimap",
  "petgraph",
  "prettyplease 0.1.25",
  "prost 0.11.9",
  "prost-types",
- "regex",
+ "regex 1.10.5",
  "syn 1.0.109",
  "tempfile",
  "which",
@@ -2462,6 +2555,7 @@ dependencies = [
  "env_logger 0.11.5",
  "futures",
  "gethostname",
+ "hashers",
  "log",
  "mockall",
  "once_cell",
@@ -2518,7 +2612,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2602,7 +2696,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2616,7 +2710,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2670,6 +2764,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
@@ -2679,12 +2779,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+dependencies = [
+ "aho-corasick 0.5.3",
+ "memchr 0.1.11",
+ "regex-syntax 0.3.9",
+ "thread_local 0.2.7",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
- "aho-corasick",
- "memchr",
+ "aho-corasick 1.1.3",
+ "memchr 2.7.4",
  "regex-automata 0.4.7",
  "regex-syntax 0.8.4",
 ]
@@ -2704,10 +2817,16 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
- "aho-corasick",
- "memchr",
+ "aho-corasick 1.1.3",
+ "memchr 2.7.4",
  "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 
 [[package]]
 name = "regex-syntax"
@@ -3004,7 +3123,7 @@ checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
- "memchr",
+ "memchr 2.7.4",
  "ryu",
  "serde",
 ]
@@ -3098,7 +3217,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "lazy_static",
+ "lazy_static 1.5.0",
 ]
 
 [[package]]
@@ -3189,7 +3308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3347,6 +3466,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
+dependencies = [
+ "thread-id",
 ]
 
 [[package]]
@@ -3684,10 +3822,10 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex 1.10.5",
  "sharded-slab",
  "smallvec",
- "thread_local",
+ "thread_local 1.1.8",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
@@ -3708,7 +3846,7 @@ dependencies = [
  "futures-util",
  "idna 0.2.3",
  "ipnet",
- "lazy_static",
+ "lazy_static 1.5.0",
  "log",
  "rand 0.8.5",
  "smallvec",
@@ -3727,7 +3865,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "ipconfig",
- "lazy_static",
+ "lazy_static 1.5.0",
  "log",
  "lru-cache",
  "parking_lot",
@@ -3795,6 +3933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,6 +3961,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 
 [[package]]
 name = "utf8parse"
@@ -4013,6 +4163,12 @@ checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -4020,6 +4176,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -4228,6 +4390,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "zoneinfo_parse"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5eceb1890eabb18cbfe5c09adc06ddaabac793269b90356fbda809c4bfe65de"
+dependencies = [
+ "datetime",
+ "lazy_static 0.2.11",
+ "regex 0.1.80",
 ]
 
 [[package]]

--- a/query-container/query-host/Cargo.toml
+++ b/query-container/query-host/Cargo.toml
@@ -34,6 +34,7 @@ opentelemetry_sdk = {version = "0.20", features = ["rt-tokio"]}
 tracing = "0.1.37"
 tracing-opentelemetry = "0.21"
 tracing-subscriber = {version = "0.3.17", features = ["env-filter"]}
+hashers = "1.0.1"
 
 [dev-dependencies]
 mockall = "0.12"

--- a/query-container/query-host/src/index_factory.rs
+++ b/query-container/query-host/src/index_factory.rs
@@ -171,7 +171,7 @@ impl IndexFactory {
     pub async fn build(
         &self,
         store: &Option<String>,
-        query_id: &str,        
+        query_id: &str,
     ) -> Result<IndexSet, IndexError> {
         let store = match store {
             Some(store) => store,
@@ -205,8 +205,7 @@ impl IndexFactory {
                 cache_size,
             } => {
                 let element_index =
-                    GarnetElementIndex::connect(query_id, connection_string)
-                        .await?;
+                    GarnetElementIndex::connect(query_id, connection_string).await?;
 
                 let element_index = Arc::new(element_index);
                 let result_index = GarnetResultIndex::connect(query_id, connection_string).await?;
@@ -255,8 +254,7 @@ impl IndexFactory {
                     archive_enabled: *enable_archive,
                     direct_io: *direct_io,
                 };
-                let element_index =
-                    RocksDbElementIndex::new(query_id, "/data", options)?;
+                let element_index = RocksDbElementIndex::new(query_id, "/data", options)?;
                 let element_index = Arc::new(element_index);
 
                 let result_index = RocksDbResultIndex::new(query_id, "/data")?;

--- a/query-container/query-host/src/main.rs
+++ b/query-container/query-host/src/main.rs
@@ -25,6 +25,7 @@ mod change_stream;
 mod future_consumer;
 mod index_factory;
 mod models;
+mod partition_selector;
 mod query_actor;
 mod query_worker;
 mod result_publisher;

--- a/query-container/query-host/src/models.rs
+++ b/query-container/query-host/src/models.rs
@@ -1,9 +1,11 @@
 use std::{
+    collections::HashMap,
     error::Error,
     fmt::{Display, Formatter},
     sync::{Arc, RwLock},
 };
 
+use drasi_core::models::{QueryJoin, SourceMiddlewareConfig};
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 
@@ -119,4 +121,32 @@ impl Error for QueryError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct QuerySourceElement {
+    pub source_label: String,
+    pub partition_key: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QuerySubscription {
+    pub nodes: Vec<QuerySourceElement>,
+    pub relations: Vec<QuerySourceElement>,
+    pub pipeline: Vec<Arc<str>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryConfig {
+    pub mode: String,
+    pub query: String,
+    pub sources: QuerySources,
+    pub storage_profile: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QuerySources {
+    pub subscriptions: HashMap<String, QuerySubscription>,
+    pub joins: Vec<QueryJoin>,
+    pub middleware: Vec<SourceMiddlewareConfig>,
 }

--- a/query-container/query-host/src/partition_selector.rs
+++ b/query-container/query-host/src/partition_selector.rs
@@ -1,0 +1,108 @@
+use std::hash::Hasher;
+
+use hashers::jenkins::spooky_hash::SpookyHasher;
+
+use crate::{
+    api::{ChangeEvent, ChangeType, ElementType},
+    models::QuerySubscription,
+};
+
+pub trait PartitionSelector {
+    fn include_in_partition(
+        &self,
+        subscription: &QuerySubscription,
+        partition_id: u64,
+        partition_count: u64,
+    ) -> bool;
+}
+
+pub fn bucket_value<T: std::hash::Hash + Eq>(value: &T, partition_count: u64) -> u64 {
+    let mut hasher = SpookyHasher::default();
+    value.hash(&mut hasher);
+    let hash_value = hasher.finish();
+
+    hash_value % partition_count
+}
+
+impl PartitionSelector for ChangeEvent {
+    fn include_in_partition(
+        &self,
+        subscription: &QuerySubscription,
+        partition_id: u64,
+        partition_count: u64,
+    ) -> bool {
+        if partition_count == 1 {
+            return true;
+        }
+
+        let change_payload = match &self.op {
+            ChangeType::Insert => &self.after,
+            ChangeType::Update => &self.after,
+            ChangeType::Delete => &self.before,
+            _ => return true,
+        };
+
+        if let None = change_payload {
+            return true;
+        }
+        let change_payload = match change_payload.as_ref() {
+            Some(payload) => payload,
+            None => return true,
+        };
+
+        let labels = match &change_payload.labels {
+            Some(labels) => labels,
+            None => return true,
+        };
+
+        let properties = match &change_payload.properties {
+            Some(properties) => properties,
+            None => return true,
+        };
+
+        let element_type = match &self.element_type {
+            Some(element_type) => element_type,
+            None => return true,
+        };
+
+        match element_type {
+            ElementType::Node => {
+                for subscription_node in &subscription.nodes {
+                    if labels.contains(&subscription_node.source_label) {
+                        match &subscription_node.partition_key {
+                            Some(partition_key) => match properties.get(partition_key) {
+                                Some(value) => {
+                                    let value_partition_id = bucket_value(value, partition_count);
+                                    if value_partition_id == partition_id {
+                                        return true;
+                                    }
+                                }
+                                None => return true,
+                            },
+                            None => return true,
+                        }
+                    }
+                }
+            }
+            ElementType::Relation => {
+                for subscription_node in &subscription.relations {
+                    if labels.contains(&subscription_node.source_label) {
+                        match &subscription_node.partition_key {
+                            Some(partition_key) => match properties.get(partition_key) {
+                                Some(value) => {
+                                    let value_partition_id = bucket_value(value, partition_count);
+                                    if value_partition_id == partition_id {
+                                        return true;
+                                    }
+                                }
+                                None => return true,
+                            },
+                            None => return true,
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+}

--- a/query-container/query-host/src/query_actor.rs
+++ b/query-container/query-host/src/query_actor.rs
@@ -249,7 +249,16 @@ impl QueryActor {
     pub async fn get_status(&self) -> Json<QueryStatus> {
         log::info!("Query get status - {}", self.query_id);
 
+        let partition = match self.config.get().await {
+            Some(c) => match c.partition {
+                Some(p) => Some(p.id),
+                None => None,
+            },
+            None => None,
+        };
+
         Json(QueryStatus {
+            partition,
             host_name: gethostname().to_str().unwrap_or_default().to_string(),
             status: self.lifecycle.get_state().to_string(),
             container: self.query_container_id.to_string(),

--- a/query-container/query-host/src/result_publisher.rs
+++ b/query-container/query-host/src/result_publisher.rs
@@ -25,8 +25,12 @@ impl ResultPublisher {
     }
 
     #[tracing::instrument(skip(self, data), err)]
-    pub async fn publish(&self, query_id: &str, data: ResultEvent) -> Result<(), Box<dyn Error>> {
-        let topic = format!("{}-results", query_id);
+    pub async fn publish(
+        &self,
+        result_stream_name: &str,
+        data: ResultEvent,
+    ) -> Result<(), Box<dyn Error>> {
+        let topic = format!("{}-results", result_stream_name);
         log::info!("Publishing {:#?}", data);
 
         let mut request = self


### PR DESCRIPTION
# Description

Initial implementation of partitioned queries.  Result streams are not re-merged for now (more design required), reactions need to subscribe to each partition.

Query writes can specify a partition count and a key per source element.  Elements without a partition key will be duplicated in each partition.

Example:

```yaml
apiVersion: v1
kind: ContinuousQuery
name: freezer
spec:
  mode: query
  partitionCount: 3
  sources:    
    subscriptions:
      - id: daniel-test
        nodes:
          - sourceLabel: Freezer
            partitionKey: zone

  query: > 
    MATCH 
      (f:Freezer)
    WHERE drasi.trueFor(f.temp > 32, duration( { seconds: 10 } ))
    RETURN
      f.id AS id,
      f.temp AS temp
```