### PR TITLE
Fixed formatting errors in `drasi list query`

### DIFF
--- a/cli/cmd/list.go
+++ b/cli/cmd/list.go
@@ -1,15 +1,16 @@
 package cmd
 
 import (
-	"drasi.io/cli/api"
-	"drasi.io/cli/service"
 	"fmt"
-	"github.com/olekukonko/tablewriter"
-	"github.com/spf13/cobra"
 	"os"
 	"reflect"
 	"sort"
 	"strings"
+
+	"drasi.io/cli/api"
+	"drasi.io/cli/service"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
 )
 
 func NewListCommand() *cobra.Command {
@@ -103,11 +104,10 @@ Example:
 			sort.Strings(headers)
 			headers = append([]string{"id"}, headers...)
 			table.SetHeader(headers)
-
 			for _, item := range items {
 				var row []string
 				for _, col := range headers {
-					row = append(row, item[col])
+					row = append(row, strings.TrimSpace(item[col]))
 				}
 				table.Append(row)
 			}


### PR DESCRIPTION
# Description

As described in https://github.com/drasi-project/drasi-platform/issues/76, the hostname in `drasi list query` is not on the same line as the other element in the same row. This PR fixes this issue by trimming the leading and trailing white spaces.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/drasi-project/drasi-platform/issues/76
<img width="1243" alt="Screenshot 2024-10-07 at 2 32 31 PM" src="https://github.com/user-attachments/assets/30c79502-36c8-41a8-8298-9f9d055fea51">
