### PR TITLE
Resource Cleanup on delete

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Build Management API
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
-          context: ./control-planes
+          context: '.'
           file: ./control-planes/mgmt_api/Dockerfile
           platforms: linux/amd64, linux/arm64
           tags: |

--- a/cli/service/resources/default-source-providers.yaml
+++ b/cli/service/resources/default-source-providers.yaml
@@ -15,6 +15,9 @@ spec:
             default: pg
     reactivator: 
       image: source-debezium-reactivator
+      deprovisionHandler: true
+      dapr:
+        app-port: "80"
       config_schema:
         type: object
         properties:
@@ -64,6 +67,9 @@ spec:
             default: mssql
     reactivator: 
       image: source-debezium-reactivator
+      deprovisionHandler: true
+      dapr:
+        app-port: "80"
       config_schema:
         type: object
         properties:

--- a/control-planes/kubernetes_provider/Cargo.lock
+++ b/control-planes/kubernetes_provider/Cargo.lock
@@ -1222,6 +1222,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2268,6 +2269,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "version_check"

--- a/control-planes/kubernetes_provider/Cargo.toml
+++ b/control-planes/kubernetes_provider/Cargo.toml
@@ -26,4 +26,5 @@ axum = { version = "0.7.5", features = ["macros"] }
 kube-derive = "0.87.1"
 schemars = "0.8.15"
 bytes = "1.7.1"
+uuid = { version = "1.10.0", features = ["v4"] }
 

--- a/control-planes/kubernetes_provider/src/actors/mod.rs
+++ b/control-planes/kubernetes_provider/src/actors/mod.rs
@@ -68,7 +68,9 @@ impl<TSpec, TStatus> ResourceActor<TSpec, TStatus> {
     ) -> impl IntoResponse {
         log::info!("Actor configure - {} {}", self.actor_type, self.id);
         let instance_id = uuid::Uuid::new_v4().to_string();
-        let platform_specs = self.spec_builder.build(spec, &self.runtime_config, &instance_id);
+        let platform_specs = self
+            .spec_builder
+            .build(spec, &self.runtime_config, &instance_id);
 
         if let Err(err) = self.write_specs(&platform_specs).await {
             log::error!("Failed to write specs: {}", err);

--- a/control-planes/kubernetes_provider/src/actors/mod.rs
+++ b/control-planes/kubernetes_provider/src/actors/mod.rs
@@ -17,6 +17,7 @@ use resource_provider_api::models::ResourceRequest;
 use std::collections::BTreeMap;
 use std::marker;
 use tokio::sync::RwLock;
+use uuid::Uuid;
 
 pub mod querycontainer_actor;
 pub mod reaction_actor;
@@ -66,8 +67,8 @@ impl<TSpec, TStatus> ResourceActor<TSpec, TStatus> {
         DaprJson(spec): DaprJson<ResourceRequest<TSpec>>,
     ) -> impl IntoResponse {
         log::info!("Actor configure - {} {}", self.actor_type, self.id);
-
-        let platform_specs = self.spec_builder.build(spec, &self.runtime_config);
+        let instance_id = uuid::Uuid::new_v4().to_string();
+        let platform_specs = self.spec_builder.build(spec, &self.runtime_config, &instance_id);
 
         if let Err(err) = self.write_specs(&platform_specs).await {
             log::error!("Failed to write specs: {}", err);

--- a/control-planes/kubernetes_provider/src/spec_builder/mod.rs
+++ b/control-planes/kubernetes_provider/src/spec_builder/mod.rs
@@ -24,6 +24,7 @@ pub trait SpecBuilder<TSpec> {
         &self,
         source: ResourceRequest<TSpec>,
         runtime_config: &RuntimeConfig,
+        instance_id: &str,
     ) -> Vec<KubernetesSpec>;
 }
 

--- a/control-planes/kubernetes_provider/src/spec_builder/query_container.rs
+++ b/control-planes/kubernetes_provider/src/spec_builder/query_container.rs
@@ -31,6 +31,7 @@ impl SpecBuilder<QueryContainerSpec> for QueryContainerSpecBuilder {
         &self,
         source: ResourceRequest<QueryContainerSpec>,
         runtime_config: &RuntimeConfig,
+        instance_id: &str,
     ) -> Vec<KubernetesSpec> {
         let mut specs = Vec::new();
 
@@ -46,7 +47,8 @@ impl SpecBuilder<QueryContainerSpec> for QueryContainerSpecBuilder {
                 1,
                 Some(4000),
                 hashmap![
-                "QUERY_NODE_ID" => ConfigValue::Inline { value: source.id.clone() }
+                "QUERY_NODE_ID" => ConfigValue::Inline { value: source.id.clone() },
+                "INSTANCE_ID" => ConfigValue::Inline { value: instance_id.to_string() }
                 ],
                 None,
                 None,
@@ -221,7 +223,8 @@ impl SpecBuilder<QueryContainerSpec> for QueryContainerSpecBuilder {
                 Some(8080),
                 hashmap![
                     "QUERY_NODE_ID" => ConfigValue::Inline { value: source.id.clone() },
-                    "VIEW_STORE_TYPE" => ConfigValue::Inline { value: "mongo".to_string() }
+                    "VIEW_STORE_TYPE" => ConfigValue::Inline { value: "mongo".to_string() },
+                    "INSTANCE_ID" => ConfigValue::Inline { value: instance_id.to_string() }
                 ],
                 Some(hashmap![
                     "api" => 80

--- a/control-planes/kubernetes_provider/src/spec_builder/reaction.rs
+++ b/control-planes/kubernetes_provider/src/spec_builder/reaction.rs
@@ -13,7 +13,7 @@ use kube::core::ObjectMeta;
 use resource_provider_api::models::{ConfigValue, EndpointSetting, ReactionSpec, ResourceRequest};
 use serde::Serialize;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     hash::{Hash, Hasher},
 };
 
@@ -24,6 +24,7 @@ impl SpecBuilder<ReactionSpec> for ReactionSpecBuilder {
         &self,
         source: ResourceRequest<ReactionSpec>,
         runtime_config: &RuntimeConfig,
+        instance_id: &str,
     ) -> Vec<KubernetesSpec> {
         let mut specs = Vec::new();
 
@@ -34,6 +35,13 @@ impl SpecBuilder<ReactionSpec> for ReactionSpecBuilder {
             "RESTART_HACK".to_string(),
             ConfigValue::Inline {
                 value: calc_hash(&source.spec),
+            },
+        );
+
+        env.insert(
+            "INSTANCE_ID".to_string(),
+            ConfigValue::Inline {
+                value: instance_id.to_string(),
             },
         );
 

--- a/control-planes/kubernetes_provider/src/spec_builder/source.rs
+++ b/control-planes/kubernetes_provider/src/spec_builder/source.rs
@@ -24,6 +24,7 @@ impl SpecBuilder<SourceSpec> for SourceSpecBuilder {
         &self,
         source: ResourceRequest<SourceSpec>,
         runtime_config: &RuntimeConfig,
+        instance_id: &str,
     ) -> Vec<KubernetesSpec> {
         let mut specs = Vec::new();
 
@@ -39,7 +40,8 @@ impl SpecBuilder<SourceSpec> for SourceSpecBuilder {
                 1,
                 Some(3000),
                 hashmap![
-                "SOURCE_ID" => ConfigValue::Inline { value: source.id.clone() }
+                "SOURCE_ID" => ConfigValue::Inline { value: source.id.clone() },
+                "INSTANCE_ID" => ConfigValue::Inline { value: instance_id.to_string() }
                 ],
                 None,
                 None,
@@ -65,7 +67,8 @@ impl SpecBuilder<SourceSpec> for SourceSpecBuilder {
                 1,
                 Some(3000),
                 hashmap![
-                "SOURCE_ID" => ConfigValue::Inline { value: source.id.clone() }
+                "SOURCE_ID" => ConfigValue::Inline { value: source.id.clone() },
+                "INSTANCE_ID" => ConfigValue::Inline { value: instance_id.to_string() }
                 ],
                 None,
                 None,
@@ -91,7 +94,8 @@ impl SpecBuilder<SourceSpec> for SourceSpecBuilder {
                 1,
                 Some(4001),
                 hashmap![
-                "SOURCE_ID" => ConfigValue::Inline { value: source.id.clone() }
+                "SOURCE_ID" => ConfigValue::Inline { value: source.id.clone() },
+                "INSTANCE_ID" => ConfigValue::Inline { value: instance_id.to_string() }
                 ],
                 None,
                 None,
@@ -140,6 +144,14 @@ impl SpecBuilder<SourceSpec> for SourceSpecBuilder {
                     value: source.id.clone(),
                 },
             );
+
+            env_var_map.insert(
+                "INSTANCE_ID".to_string(),
+                ConfigValue::Inline {
+                    value: instance_id.to_string(),
+                },
+            );
+
             if let Some(props) = service_spec.properties {
                 for (key, value) in props {
                     env_var_map.insert(key, value);

--- a/control-planes/mgmt_api/Cargo.lock
+++ b/control-planes/mgmt_api/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -709,6 +709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,7 +739,7 @@ dependencies = [
  "derive_more",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "itoa",
  "log",
@@ -996,9 +1002,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "bytestring"
@@ -1420,6 +1426,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "drasi-comms-abstractions"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "reqwest 0.12.8",
+ "serde_json",
+]
+
+[[package]]
+name = "drasi-comms-dapr"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "drasi-comms-abstractions",
+ "reqwest 0.12.8",
+ "serde_json",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,6 +1774,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,7 +1947,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1924,6 +1970,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -1932,6 +1979,24 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls 0.23.14",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -1960,18 +2025,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
+ "socket2 0.5.7",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2167,7 +2253,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "time",
@@ -2324,6 +2410,8 @@ dependencies = [
  "cloudevents-sdk",
  "dapr",
  "derive_more",
+ "drasi-comms-abstractions",
+ "drasi-comms-dapr",
  "env_logger 0.10.2",
  "faux",
  "futures",
@@ -2337,7 +2425,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rand",
  "redis",
- "reqwest",
+ "reqwest 0.11.27",
  "resource_provider_api",
  "serde",
  "serde_json",
@@ -2430,8 +2518,8 @@ dependencies = [
  "percent-encoding",
  "rand",
  "rustc_version_runtime",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_bytes",
  "serde_with",
@@ -2443,7 +2531,7 @@ dependencies = [
  "take_mut",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "trust-dns-proto",
  "trust-dns-resolver",
@@ -3108,11 +3196,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -3121,12 +3209,12 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -3135,6 +3223,50 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "system-configuration 0.6.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3226,8 +3358,21 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3240,12 +3385,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -3619,6 +3790,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "system-configuration"
@@ -3628,7 +3802,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -3636,6 +3821,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3805,7 +4000,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.14",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -3846,7 +4052,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
@@ -3873,7 +4079,7 @@ dependencies = [
  "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
@@ -4351,6 +4557,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4527,6 +4763,12 @@ dependencies = [
  "quote",
  "syn 2.0.77",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"

--- a/control-planes/mgmt_api/Cargo.toml
+++ b/control-planes/mgmt_api/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 resource_provider_api = { path = "../resource_provider_api" }
+drasi-comms-abstractions = { path = "../../infrastructure/comms-abstractions" }
+drasi-comms-dapr = { path = "../../infrastructure/comms-dapr" }
 dapr = "=0.15.1"
 async-stream = "0.3.5"
 async-trait = "0.1"

--- a/control-planes/mgmt_api/Dockerfile
+++ b/control-planes/mgmt_api/Dockerfile
@@ -1,13 +1,16 @@
 FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
 # rust:1.81-bullseye
 RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev
+
 WORKDIR /usr/src
-COPY ./resource_provider_api ./resource_provider_api
+COPY ./infrastructure ./infrastructure
+WORKDIR /usr/src/control-planes
+COPY ./control-planes/resource_provider_api ./resource_provider_api
 RUN cargo new mgmt_api
-WORKDIR /usr/src/mgmt_api
-COPY ./mgmt_api/Cargo.toml .
+WORKDIR /usr/src/control-planes/mgmt_api
+COPY ./control-planes/mgmt_api/Cargo.toml .
 RUN cargo fetch
-COPY ./mgmt_api .
+COPY ./control-planes/mgmt_api .
 RUN cargo install --force --path .
 
 FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf

--- a/control-planes/mgmt_api/Makefile
+++ b/control-planes/mgmt_api/Makefile
@@ -8,7 +8,7 @@ DOCKERX_OPTS ?= --load --cache-to type=inline,mode=max
 default: docker-build
 
 docker-build:
-	docker buildx build .. -f ./Dockerfile -t $(IMAGE_PREFIX)/api:$(DOCKER_TAG_VERSION) $(DOCKERX_OPTS)
+	docker buildx build ../../ -f ./Dockerfile -t $(IMAGE_PREFIX)/api:$(DOCKER_TAG_VERSION) $(DOCKERX_OPTS)
 
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/api:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)

--- a/control-planes/mgmt_api/src/api/v1/mappings/providers.rs
+++ b/control-planes/mgmt_api/src/api/v1/mappings/providers.rs
@@ -36,6 +36,7 @@ impl From<ServiceConfigDto> for ServiceConfig {
         ServiceConfig {
             replica: None,
             image: None,
+            deprovision_handler: None,
             endpoints: service
                 .endpoints
                 .map(|endpoints| endpoints.into_iter().map(|(k, v)| (k, v.into())).collect()),
@@ -142,6 +143,7 @@ impl From<ProviderServiceDto> for ProviderService {
                 .endpoints
                 .map(|endpoints| endpoints.into_iter().map(|(k, v)| (k, v.into())).collect()),
             config_schema: provider_service.config_schema.map(|schema| schema.into()),
+            deprovision_handler: provider_service.deprovision_handler,
         }
     }
 }
@@ -155,6 +157,7 @@ impl From<ProviderService> for ProviderServiceDto {
                 .endpoints
                 .map(|endpoints| endpoints.into_iter().map(|(k, v)| (k, v.into())).collect()),
             config_schema: provider_service.config_schema.map(|schema| schema.into()),
+            deprovision_handler: provider_service.deprovision_handler,
         }
     }
 }

--- a/control-planes/mgmt_api/src/api/v1/models/providers.rs
+++ b/control-planes/mgmt_api/src/api/v1/models/providers.rs
@@ -17,6 +17,7 @@ pub struct ProviderServiceDto {
     pub dapr: Option<HashMap<String, String>>,
     pub endpoints: Option<HashMap<String, ServiceEndpointDto>>,
     pub config_schema: Option<JsonSchemaDto>,
+    pub deprovision_handler: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/control-planes/mgmt_api/src/api/v1/models/providers.rs
+++ b/control-planes/mgmt_api/src/api/v1/models/providers.rs
@@ -17,6 +17,7 @@ pub struct ProviderServiceDto {
     pub dapr: Option<HashMap<String, String>>,
     pub endpoints: Option<HashMap<String, ServiceEndpointDto>>,
     pub config_schema: Option<JsonSchemaDto>,
+    #[serde(rename = "deprovisionHandler")]
     pub deprovision_handler: Option<bool>,
 }
 

--- a/control-planes/mgmt_api/src/domain/models.rs
+++ b/control-planes/mgmt_api/src/domain/models.rs
@@ -212,6 +212,7 @@ pub struct ProviderService {
     pub dapr: Option<HashMap<String, String>>,
     pub endpoints: Option<HashMap<String, ServiceEndpoint>>,
     pub config_schema: Option<JsonSchema>,
+    pub deprovision_handler: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -221,12 +222,14 @@ pub struct ServiceEndpoint {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct ServiceConfig {
     pub replica: Option<String>,
     pub image: Option<String>,
     pub dapr: Option<HashMap<String, ConfigValue>>,
     pub endpoints: Option<HashMap<String, Endpoint>>,
     pub properties: Option<HashMap<String, ConfigValue>>,
+    pub deprovision_handler: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/control-planes/mgmt_api/src/domain/models.rs
+++ b/control-planes/mgmt_api/src/domain/models.rs
@@ -212,7 +212,7 @@ pub struct ProviderService {
     pub image: String,
     pub dapr: Option<HashMap<String, String>>,
     pub endpoints: Option<HashMap<String, ServiceEndpoint>>,
-    pub config_schema: Option<JsonSchema>,    
+    pub config_schema: Option<JsonSchema>,
     pub deprovision_handler: Option<bool>,
 }
 

--- a/control-planes/mgmt_api/src/domain/models.rs
+++ b/control-planes/mgmt_api/src/domain/models.rs
@@ -207,11 +207,12 @@ pub struct SourceProviderMarker;
 pub struct ReactionProviderMarker;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct ProviderService {
     pub image: String,
     pub dapr: Option<HashMap<String, String>>,
     pub endpoints: Option<HashMap<String, ServiceEndpoint>>,
-    pub config_schema: Option<JsonSchema>,
+    pub config_schema: Option<JsonSchema>,    
     pub deprovision_handler: Option<bool>,
 }
 

--- a/control-planes/mgmt_api/src/domain/resource_services/extensible/mod.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/extensible/mod.rs
@@ -524,7 +524,7 @@ fn merge_spec(
             endpoints,
             dapr,
             properties: service_properties,
-            deprovision_handler: service_config.deprovision_handler.clone(),
+            deprovision_handler: service_config.deprovision_handler,
         };
 
         services.insert(service_name.clone(), new_service);

--- a/control-planes/mgmt_api/src/domain/resource_services/extensible/mod.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/extensible/mod.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
 use dapr::client::TonicClient;
+use drasi_comms_abstractions::comms::{Invoker, Payload};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, env, fmt::Debug, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 
 use crate::{
     domain::models::{
@@ -39,6 +40,7 @@ where
     dapr_client: dapr::Client<TonicClient>,
     repo: Box<dyn ResourceSpecRepository<TSpec> + Send + Sync>,
     provider_repo: Arc<ProviderRepository>,
+    invoker: Arc<dyn Invoker>,
     actor_type: fn(&TSpec) -> String,
     ready_check: fn(&TStatus) -> bool,
     validators: Vec<Box<dyn ExtensibleSpecValidator<TSpec> + Send + Sync>>,
@@ -131,16 +133,14 @@ where
                 log::error!("Error getting schema for resource: {}", e);
                 None
             }
-        };        
+        };
         
         if let Some(schema) = &schema {
-            let client = reqwest::Client::new();
-            let port = std::env::var("DAPR_HTTP_PORT").unwrap_or("3500".to_string());
             for (service_name, service_config) in &schema.services {
                 if let Some(deprovision_handler) = &service_config.deprovision_handler {
                     if *deprovision_handler {
-                        match client.post(format!("http://localhost:{}/v1.0/invoke/{}/method/deprovision", port, format!("{}-{}", id, service_name))).send().await {
-                            Ok(r) => log::info!("Deprovisioned {}-{}: {}", id, service_name, r.status()),                            
+                        match self.invoker.invoke(Payload::None, format!("{}-{}", id, service_name).as_str(), "deprovision", None).await {
+                            Ok(_) => log::info!("Called Deprovision handler for {}-{}", id, service_name),
                             Err(e) => {
                                 log::error!("Error deprovisioning {}-{}: {}", id, service_name, e.to_string());                                    
                             }

--- a/control-planes/mgmt_api/src/domain/resource_services/extensible/reaction_service.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/extensible/reaction_service.rs
@@ -11,6 +11,7 @@ use crate::{
 
 use async_trait::async_trait;
 use dapr::client::TonicClient;
+use drasi_comms_abstractions::comms::Invoker;
 use jsonschema::JSONSchema;
 use std::{collections::HashMap, sync::Arc};
 pub type ReactionDomainService = dyn ResourceDomainService<ReactionSpec, ReactionStatus>;
@@ -26,11 +27,13 @@ impl ReactionDomainServiceImpl {
         dapr_client: dapr::Client<TonicClient>,
         repo: Box<ReactionRepository>,
         provider_repo: Arc<ProviderRepository>,
+        invoker: Arc<dyn Invoker>
     ) -> Self {
         ReactionDomainServiceImpl {
             dapr_client,
             repo,
             provider_repo,
+            invoker,
             actor_type: |_spec| "ReactionResource".to_string(),
             ready_check: |status| status.available,
             validators: vec![Box::new(ReactionSpecValidator {})],

--- a/control-planes/mgmt_api/src/domain/resource_services/extensible/reaction_service.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/extensible/reaction_service.rs
@@ -27,7 +27,7 @@ impl ReactionDomainServiceImpl {
         dapr_client: dapr::Client<TonicClient>,
         repo: Box<ReactionRepository>,
         provider_repo: Arc<ProviderRepository>,
-        invoker: Arc<dyn Invoker>
+        invoker: Arc<dyn Invoker>,
     ) -> Self {
         ReactionDomainServiceImpl {
             dapr_client,

--- a/control-planes/mgmt_api/src/domain/resource_services/extensible/source_service.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/extensible/source_service.rs
@@ -163,7 +163,7 @@ impl ExtensibleSpecValidator<SourceSpec> for SourceSpecValidator {
             }
         };
         // Check if the services defined in the source spec are defined in the schema
-        for (service_name, _service_settings) in &services {
+        for service_name in services.keys() {
             if !defined_services.contains(service_name) {
                 return Err(DomainError::UndefinedSetting {
                     message: format!("Service {} is not defined in the schema", service_name),

--- a/control-planes/mgmt_api/src/domain/resource_services/extensible/source_service.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/extensible/source_service.rs
@@ -27,7 +27,7 @@ impl SourceDomainServiceImpl {
         dapr_client: dapr::Client<TonicClient>,
         repo: Box<SourceRepository>,
         provider_repo: Arc<ProviderRepository>,
-        invoker: Arc<dyn Invoker>
+        invoker: Arc<dyn Invoker>,
     ) -> Self {
         SourceDomainServiceImpl {
             dapr_client,

--- a/control-planes/mgmt_api/src/domain/resource_services/extensible/source_service.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/extensible/source_service.rs
@@ -9,6 +9,7 @@ use crate::{
     ProviderRepository,
 };
 use dapr::client::TonicClient;
+use drasi_comms_abstractions::comms::Invoker;
 use jsonschema::JSONSchema;
 use std::{collections::HashMap, sync::Arc};
 
@@ -26,11 +27,13 @@ impl SourceDomainServiceImpl {
         dapr_client: dapr::Client<TonicClient>,
         repo: Box<SourceRepository>,
         provider_repo: Arc<ProviderRepository>,
+        invoker: Arc<dyn Invoker>
     ) -> Self {
         SourceDomainServiceImpl {
             dapr_client,
             repo,
             provider_repo,
+            invoker,
             actor_type: |_spec| "SourceResource".to_string(),
             ready_check: |status| status.available,
             validators: vec![Box::new(SourceSpecValidator {})],

--- a/control-planes/mgmt_api/src/domain/resource_services/extensible/source_service.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/extensible/source_service.rs
@@ -160,7 +160,7 @@ impl ExtensibleSpecValidator<SourceSpec> for SourceSpecValidator {
             }
         };
         // Check if the services defined in the source spec are defined in the schema
-        for (service_name, service_settings) in &services {
+        for (service_name, _service_settings) in &services {
             if !defined_services.contains(service_name) {
                 return Err(DomainError::UndefinedSetting {
                     message: format!("Service {} is not defined in the schema", service_name),

--- a/control-planes/mgmt_api/src/main.rs
+++ b/control-planes/mgmt_api/src/main.rs
@@ -30,7 +30,10 @@ async fn main() -> Result<(), std::io::Error> {
 
     let mongo_db = std::env::var("MONGO_DB").unwrap_or("api".to_string());
     let redis_url = std::env::var("REDIS_URL").unwrap_or("redis://drasi-redis:6379".to_string());
-    let dapr_http_port = std::env::var("DAPR_HTTP_PORT").unwrap_or_else(|_| "3500".to_string()).parse::<u16>().unwrap();
+    let dapr_http_port = std::env::var("DAPR_HTTP_PORT")
+        .unwrap_or_else(|_| "3500".to_string())
+        .parse::<u16>()
+        .unwrap();
 
     // Introduce delay so that dapr grpc port is assigned before app tries to connect
     std::thread::sleep(std::time::Duration::new(5, 0));
@@ -47,7 +50,10 @@ async fn main() -> Result<(), std::io::Error> {
     HttpServer::new(move || {
         //todo: investigate IoC container
         let db = mongo_client.database(&mongo_db);
-        let invoker = Arc::new(DaprHttpInvoker::new("127.0.0.1".to_string(), dapr_http_port));
+        let invoker = Arc::new(DaprHttpInvoker::new(
+            "127.0.0.1".to_string(),
+            dapr_http_port,
+        ));
 
         let source_provider_repo =
             Arc::new(ProviderRepositoryImpl::new(db.clone(), "source_schemas"));
@@ -59,7 +65,7 @@ async fn main() -> Result<(), std::io::Error> {
             dapr_client.clone(),
             Box::new(source_repo),
             source_provider_repo.clone(),
-            invoker.clone()
+            invoker.clone(),
         );
 
         let source_domain_svc_arc: web::Data<SourceDomainService> =
@@ -78,7 +84,7 @@ async fn main() -> Result<(), std::io::Error> {
             dapr_client.clone(),
             Box::new(reaction_repo),
             reaction_provider_repo.clone(),
-            invoker.clone()
+            invoker.clone(),
         );
         let reaction_domain_svc_arc: web::Data<ReactionDomainService> =
             web::Data::from(Arc::new(reaction_domain_svc) as Arc<ReactionDomainService>);

--- a/control-planes/mgmt_api/src/main.rs
+++ b/control-planes/mgmt_api/src/main.rs
@@ -3,6 +3,7 @@ use domain::resource_provider_services::{
     ReactionProviderDomainService, ReactionProviderDomainServiceImpl, SourceProviderDomainService,
     SourceProviderDomainServiceImpl,
 };
+use drasi_comms_dapr::comms::DaprHttpInvoker;
 use std::sync::Arc;
 
 use crate::{
@@ -29,6 +30,7 @@ async fn main() -> Result<(), std::io::Error> {
 
     let mongo_db = std::env::var("MONGO_DB").unwrap_or("api".to_string());
     let redis_url = std::env::var("REDIS_URL").unwrap_or("redis://drasi-redis:6379".to_string());
+    let dapr_http_port = std::env::var("DAPR_HTTP_PORT").unwrap_or_else(|_| "3500".to_string()).parse::<u16>().unwrap();
 
     // Introduce delay so that dapr grpc port is assigned before app tries to connect
     std::thread::sleep(std::time::Duration::new(5, 0));
@@ -45,6 +47,7 @@ async fn main() -> Result<(), std::io::Error> {
     HttpServer::new(move || {
         //todo: investigate IoC container
         let db = mongo_client.database(&mongo_db);
+        let invoker = Arc::new(DaprHttpInvoker::new("127.0.0.1".to_string(), dapr_http_port));
 
         let source_provider_repo =
             Arc::new(ProviderRepositoryImpl::new(db.clone(), "source_schemas"));
@@ -56,6 +59,7 @@ async fn main() -> Result<(), std::io::Error> {
             dapr_client.clone(),
             Box::new(source_repo),
             source_provider_repo.clone(),
+            invoker.clone()
         );
 
         let source_domain_svc_arc: web::Data<SourceDomainService> =
@@ -74,6 +78,7 @@ async fn main() -> Result<(), std::io::Error> {
             dapr_client.clone(),
             Box::new(reaction_repo),
             reaction_provider_repo.clone(),
+            invoker.clone()
         );
         let reaction_domain_svc_arc: web::Data<ReactionDomainService> =
             web::Data::from(Arc::new(reaction_domain_svc) as Arc<ReactionDomainService>);

--- a/infrastructure/comms-abstractions/src/comms.rs
+++ b/infrastructure/comms-abstractions/src/comms.rs
@@ -17,20 +17,25 @@ impl Headers {
     }
 }
 
+pub enum Payload {
+    None,
+    Json(Value),
+    Bytes(bytes::Bytes),
+}
+
 #[async_trait]
-pub trait Invoker {
-    fn new(dapr_host: String, dapr_port: u16) -> Self;
+pub trait Invoker: Send + Sync {
     async fn invoke(
         &self,
-        data: Value,
-        app_id: String,
-        method: String,
-        headers: Headers,
+        data: Payload,
+        app_id: &str,
+        method: &str,
+        headers: Option<Headers>,
     ) -> Result<bytes::Bytes, Box<dyn std::error::Error>>;
 }
 
 #[async_trait]
-pub trait Publisher {
+pub trait Publisher: Send + Sync {
     fn new(dapr_host: String, dapr_port: u16, pubsub: String, topic: String) -> Self;
     async fn publish(
         &self,

--- a/infrastructure/comms-dapr/src/comms.rs
+++ b/infrastructure/comms-dapr/src/comms.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use drasi_comms_abstractions::comms::{Headers, Invoker, Publisher};
+use drasi_comms_abstractions::comms::{Headers, Invoker, Payload, Publisher};
 use serde_json::Value;
 pub struct DaprHttpPublisher {
     client: reqwest::Client,
@@ -65,47 +65,65 @@ pub struct DaprHttpInvoker {
     dapr_port: u16,
 }
 
-#[async_trait]
-impl Invoker for DaprHttpInvoker {
-    fn new(dapr_host: String, dapr_port: u16) -> Self {
+impl DaprHttpInvoker {
+    pub fn new(dapr_host: String, dapr_port: u16) -> Self {
         DaprHttpInvoker {
             client: reqwest::Client::new(),
             dapr_host,
             dapr_port,
         }
     }
+}
 
+#[async_trait]
+impl Invoker for DaprHttpInvoker {
     async fn invoke(
         &self,
-        data: Value,
-        app_id: String,
-        method: String,
-        headers: Headers,
-    ) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
-        let url = format!("http://{}:{}/{}", self.dapr_host, self.dapr_port, method);
+        data: Payload,
+        app_id: &str,
+        method: &str,
+        headers: Option<Headers>,
+    ) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {        
+        let url = format!("http://{}:{}/v1.0/invoke/{}/method/{}", self.dapr_host, self.dapr_port, app_id, method);
+        
+        let request_headers = {
+            let mut request_headers = reqwest::header::HeaderMap::new();
+            if let Some(headers) = headers {
+                for (key, value) in headers.headers.iter() {
+                    request_headers.insert(
+                        key.parse::<reqwest::header::HeaderName>()?,
+                        value.parse()?,
+                    );
+                }
+            }
 
-        let mut request_headers = reqwest::header::HeaderMap::new();
-        let headers = headers.headers.clone();
-        for (key, value) in headers.iter() {
-            request_headers.insert(
-                key.parse::<reqwest::header::HeaderName>().unwrap(),
-                value.parse().unwrap(),
-            );
-        }
+            if !request_headers.contains_key("Content-Type") {
+                match data {
+                    Payload::Json(_) => {
+                        request_headers.insert("Content-Type", "application/json".parse()?);
+                    }
+                    Payload::Bytes(_) => {
+                        request_headers.insert("Content-Type", "application/octet-stream".parse()?);
+                    }
+                    _ => {}
+                }
+            }
+            
+            request_headers
+        };
 
-        if !request_headers.contains_key("Content-Type") {
-            request_headers.insert("Content-Type", "application/json".parse().unwrap());
-        }
-
-        request_headers.insert("dapr-app-id", app_id.parse().unwrap());
-
-        let response = self
+        let request = self
             .client
             .post(url)
-            .headers(request_headers)
-            .json(&data)
-            .send()
-            .await;
+            .headers(request_headers);
+
+        let request = match data {
+            Payload::Json(data) => request.json(&data),
+            Payload::Bytes(data) => request.body(data),
+            _ => request,
+        };
+
+        let response = request.send().await;
 
         match response {
             Ok(resp) => {

--- a/infrastructure/comms-dapr/src/comms.rs
+++ b/infrastructure/comms-dapr/src/comms.rs
@@ -83,17 +83,18 @@ impl Invoker for DaprHttpInvoker {
         app_id: &str,
         method: &str,
         headers: Option<Headers>,
-    ) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {        
-        let url = format!("http://{}:{}/v1.0/invoke/{}/method/{}", self.dapr_host, self.dapr_port, app_id, method);
-        
+    ) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
+        let url = format!(
+            "http://{}:{}/v1.0/invoke/{}/method/{}",
+            self.dapr_host, self.dapr_port, app_id, method
+        );
+
         let request_headers = {
             let mut request_headers = reqwest::header::HeaderMap::new();
             if let Some(headers) = headers {
                 for (key, value) in headers.headers.iter() {
-                    request_headers.insert(
-                        key.parse::<reqwest::header::HeaderName>()?,
-                        value.parse()?,
-                    );
+                    request_headers
+                        .insert(key.parse::<reqwest::header::HeaderName>()?, value.parse()?);
                 }
             }
 
@@ -108,14 +109,11 @@ impl Invoker for DaprHttpInvoker {
                     _ => {}
                 }
             }
-            
+
             request_headers
         };
 
-        let request = self
-            .client
-            .post(url)
-            .headers(request_headers);
+        let request = self.client.post(url).headers(request_headers);
 
         let request = match data {
             Payload::Json(data) => request.json(&data),

--- a/sources/.gitignore
+++ b/sources/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/sources/relational/debezium-reactivator/pom.xml
+++ b/sources/relational/debezium-reactivator/pom.xml
@@ -88,6 +88,22 @@
       <version>2.10.1</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>3.3.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/sources/relational/debezium-reactivator/src/main/java/com/drasi/AppConfig.java
+++ b/sources/relational/debezium-reactivator/src/main/java/com/drasi/AppConfig.java
@@ -1,0 +1,38 @@
+package com.drasi;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@Configuration
+public class AppConfig {
+
+    @Value("${drasi.sourceid}")
+    private String sourceId;
+
+    @Value("${drasi.connector}")
+    private String connector;
+
+    @Bean
+    public ChangeMonitor changeMonitor() throws SQLException, IOException {
+
+        var publisher = new DaprChangePublisher(sourceId);
+
+        ChangeMonitor monitor;
+        switch (System.getenv("connector")) {
+            case "PostgreSQL":
+                monitor = new PostgresChangeMonitor(sourceId, publisher);
+                break;
+            case "SQLServer":
+                monitor = new SqlServerChangeMonitor(sourceId, publisher);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown connector");
+        }
+
+        return monitor;
+    }
+}

--- a/sources/relational/debezium-reactivator/src/main/java/com/drasi/AppLifecycle.java
+++ b/sources/relational/debezium-reactivator/src/main/java/com/drasi/AppLifecycle.java
@@ -1,0 +1,60 @@
+package com.drasi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@Component
+public class AppLifecycle implements SmartLifecycle {
+
+    private static final Logger log = LoggerFactory.getLogger(AppLifecycle.class);
+    private boolean isRunning = false;
+
+    private final ChangeMonitor changeMonitor;
+
+    @Autowired
+    public AppLifecycle(@Qualifier("changeMonitor") ChangeMonitor changeMonitor) {
+        this.changeMonitor = changeMonitor;
+    }
+
+    @Override
+    public void start() {
+        try {
+            log.info("Reactivator is starting.");
+            changeMonitor.run();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        isRunning = true;
+
+    }
+
+    @Override
+    public void stop() {
+        log.info("Reactivator is stopping.");
+        try {
+            changeMonitor.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        isRunning = false;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return isRunning;
+    }
+
+    @Override
+    public int getPhase() {
+        return 0; // Defines the phase in which this component should start
+    }
+}

--- a/sources/relational/debezium-reactivator/src/main/java/com/drasi/ChangeMonitor.java
+++ b/sources/relational/debezium-reactivator/src/main/java/com/drasi/ChangeMonitor.java
@@ -5,4 +5,5 @@ import java.sql.SQLException;
 
 public interface ChangeMonitor {
     void run() throws IOException, SQLException;
+    void close() throws Exception;
 }

--- a/sources/relational/debezium-reactivator/src/main/java/com/drasi/DeprovisionController.java
+++ b/sources/relational/debezium-reactivator/src/main/java/com/drasi/DeprovisionController.java
@@ -1,0 +1,56 @@
+package com.drasi;
+
+import io.dapr.client.DaprClient;
+import io.dapr.client.DaprClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@RestController
+public class DeprovisionController {
+
+    private static final Logger log = LoggerFactory.getLogger(DeprovisionController.class);
+
+    private DaprClient client;
+    private String stateStore;
+    private ChangeMonitor changeMonitor;
+
+    @Autowired
+    public DeprovisionController(@Qualifier("changeMonitor") ChangeMonitor changeMonitor) {
+        this.client = new DaprClientBuilder().build();
+        this.stateStore = "drasi-state";
+        this.changeMonitor = changeMonitor;
+    }
+
+    /**
+     * Handles a dapr service invocation endpoint on this app.
+     * @param body The body of the http message.
+     * @param headers The headers of the http message.
+     * @return A message containing the time.
+     */
+    @PostMapping(path = "/deprovision")
+    public Mono<ResponseEntity<Void>> handleMethod(@RequestBody(required = false) byte[] body,
+                                                   @RequestHeader Map<String, String> headers) {
+        return Mono.fromSupplier(() -> {
+            try {
+                log.info("Deprovisioning...");
+                changeMonitor.close();
+                client.deleteState(stateStore, "offset").block();
+                return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+}

--- a/sources/relational/debezium-reactivator/src/main/java/com/drasi/PostgresChangeMonitor.java
+++ b/sources/relational/debezium-reactivator/src/main/java/com/drasi/PostgresChangeMonitor.java
@@ -6,18 +6,24 @@ import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.format.Json;
 import io.debezium.engine.spi.OffsetCommitPolicy;
+import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class PostgresChangeMonitor implements ChangeMonitor {
     private String sourceId;
     private ChangePublisher publisher;
+    private ExecutorService executor;
+    private DebeziumEngine<ChangeEvent<String, String>> engine;
 
     public PostgresChangeMonitor(String sourceId, ChangePublisher publisher) {
         this.sourceId = sourceId;
         this.publisher = publisher;
+        this.executor = Executors.newSingleThreadExecutor();
     }
 
     public void run() throws IOException, SQLException {
@@ -55,12 +61,18 @@ public class PostgresChangeMonitor implements ChangeMonitor {
 
         final Properties props = config.asProperties();
 
-        try (DebeziumEngine<ChangeEvent<String, String>> engine = DebeziumEngine.create(Json.class)
+        engine = DebeziumEngine.create(Json.class)
                 .using(props)
                 .using(OffsetCommitPolicy.always())
-                .notifying(new PostgresChangeConsumer(mappings, publisher)).build()) {
-            engine.run();
-        }
+                .notifying(new PostgresChangeConsumer(mappings, publisher)).build();
+
+        executor.execute(engine);
+    }
+
+    public void close() throws Exception {
+        engine.close();
+        executor.shutdown();
+        executor.awaitTermination(10, java.util.concurrent.TimeUnit.SECONDS);
     }
 
     private static String CleanPublicationName(String name) {

--- a/sources/relational/debezium-reactivator/src/main/java/com/drasi/Reactivator.java
+++ b/sources/relational/debezium-reactivator/src/main/java/com/drasi/Reactivator.java
@@ -22,11 +22,13 @@ public class Reactivator {
         try {
             var sourceId = System.getenv("SOURCE_ID");
             var connector = System.getenv("connector");
+            var instanceId = System.getenv("INSTANCE_ID");
             SpringApplication app = new SpringApplication(Reactivator.class);
             Map<String, Object> defaultProperties = new HashMap<>();
             defaultProperties.put("server.port", "80");
             defaultProperties.put("drasi.sourceid", sourceId);
             defaultProperties.put("drasi.connector", connector);
+            defaultProperties.put("drasi.instanceid", instanceId);
             app.setDefaultProperties(defaultProperties);
             app.run(args);
         } catch (Exception ex) {

--- a/sources/relational/debezium-reactivator/src/main/java/com/drasi/Reactivator.java
+++ b/sources/relational/debezium-reactivator/src/main/java/com/drasi/Reactivator.java
@@ -2,35 +2,33 @@ package com.drasi;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
+@SpringBootApplication
 public class Reactivator {
 
     private static final Logger log = LoggerFactory.getLogger(Reactivator.class);
 
     public static void main(String[] args) throws IOException, SQLException {
 
-        try {            
+        try {
             var sourceId = System.getenv("SOURCE_ID");
-            var publisher = new DaprChangePublisher(sourceId);
-
-            ChangeMonitor monitor;
-            switch (System.getenv("connector")) {
-                case "PostgreSQL":
-                    monitor = new PostgresChangeMonitor(sourceId, publisher);
-                    break;
-                case "SQLServer":
-                    monitor = new SqlServerChangeMonitor(sourceId, publisher);
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown connector");
-            }
-            monitor.run();
-
+            var connector = System.getenv("connector");
+            SpringApplication app = new SpringApplication(Reactivator.class);
+            Map<String, Object> defaultProperties = new HashMap<>();
+            defaultProperties.put("server.port", "80");
+            defaultProperties.put("drasi.sourceid", sourceId);
+            defaultProperties.put("drasi.connector", connector);
+            app.setDefaultProperties(defaultProperties);
+            app.run(args);
         } catch (Exception ex) {
             log.error(ex.getMessage());
             Files.write(Path.of("/dev/termination-log"), ex.getMessage().getBytes());

--- a/sources/shared/change-dispatcher/src/main.rs
+++ b/sources/shared/change-dispatcher/src/main.rs
@@ -201,7 +201,7 @@ async fn process_changes(
                 match invoker
                     .invoke(
                         Payload::Json(dispatch_event.clone()),
-                        app_id.into(),
+                        &app_id,
                         "change",
                         Some(headers),
                     )

--- a/sources/shared/change-dispatcher/src/main.rs
+++ b/sources/shared/change-dispatcher/src/main.rs
@@ -1,4 +1,5 @@
 use change_dispatcher_config::ChangeDispatcherConfig;
+use drasi_comms_abstractions::comms::Payload;
 use log::info;
 use serde_json::Value;
 
@@ -199,10 +200,10 @@ async fn process_changes(
                 let headers = Headers::new(headers);
                 match invoker
                     .invoke(
-                        dispatch_event.clone(),
-                        app_id,
-                        "change".to_string(),
-                        headers,
+                        Payload::Json(dispatch_event.clone()),
+                        app_id.into(),
+                        "change",
+                        Some(headers),
                     )
                     .await
                 {


### PR DESCRIPTION
# Description

This PR adds infrastructure to clean up resources when sources / reactions are deleted.  It takes a 2 pronged approach.

The first is to add an optional `deprovisionHandler` to any resource service.  This is defined on the Source / Reaction Provider spec. When the resource is deleted, the control plane will do a best effort attempt to call the deprovision method on the service, using standard Dapr retry semantics. If the handler is not callable, to resource will still be deleted.

To second, is to include an `INSTANCE_ID` environment variable on each service.  This value remains the same for the lifetime of the resource (source/reaction). If you delete and recreate the resource with the same name, the instance id will change. Thus the service can inspect if the instance id is as expected, if not then any existing state should be considered stale.

Both mechanisms have been implemented for the debezium reactivator.