### PR TITLE
Clear stream cursor for deleted queries

### DIFF
--- a/query-container/query-host/src/change_stream/redis_change_stream.rs
+++ b/query-container/query-host/src/change_stream/redis_change_stream.rs
@@ -183,10 +183,7 @@ impl SequentialChangeStream for RedisChangeStream {
     async fn unsubscribe(&self) -> Result<(), ChangeStreamError> {
         _ = self.cancel.notify_one();
         let mut connection = self.connection.lock().await;
-        let _: i64 = match connection
-            .xgroup_destroy(&self.topic, &self.group_id)
-            .await
-        {
+        let _: i64 = match connection.xgroup_destroy(&self.topic, &self.group_id).await {
             Ok(res) => {
                 log::debug!("unsubscribe response: {:?}", res);
                 res

--- a/query-container/query-host/src/change_stream/redis_change_stream.rs
+++ b/query-container/query-host/src/change_stream/redis_change_stream.rs
@@ -184,7 +184,7 @@ impl SequentialChangeStream for RedisChangeStream {
         _ = self.cancel.notify_one();
         let mut connection = self.connection.lock().await;
         let _: i64 = match connection
-            .xgroup_delconsumer(&self.topic, &self.group_id, "qh")
+            .xgroup_destroy(&self.topic, &self.group_id)
             .await
         {
             Ok(res) => {


### PR DESCRIPTION
# Description

When a query is deleted, the cursor for the query container stream is not removed, so when another query with the same name is created, it assumes the old cursor from the previous query.  This PR deletes the cursor when the query is deleted.

## Type of change

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
