### PR TITLE
Add cli flag to enable skipping dapr install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+      "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+      "ghcr.io/devcontainers/features/rust:1": {},
+      "ghcr.io/devcontainers/features/go:1": {},
+      "ghcr.io/devcontainers/features/node:1": {},
+      "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+      "ghcr.io/devcontainers-extra/features/kind:1": {}
+  }
+}

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -79,6 +79,11 @@ Usage examples:
 			clusterConfig.DaprSidecarVersion = sidecarVersion
 			saveConfig(clusterConfig)
 
+			var skipDaprInstall bool
+			if skipDaprInstall, err = cmd.Flags().GetBool("skip-dapr-install"); err != nil {
+				return err
+			}
+
 			if installer, err = service.MakeInstaller(namespace); err != nil {
 				return err
 			}
@@ -92,7 +97,7 @@ Usage examples:
 			output := output.NewTaskOutput()
 			defer output.Close()
 
-			if err := installer.Install(local, registry, version, output, namespace); err != nil {
+			if err := installer.Install(local, registry, version, output, namespace, skipDaprInstall); err != nil {
 				return err
 			}
 
@@ -106,5 +111,6 @@ Usage examples:
 	initCommand.Flags().StringP("namespace", "n", "drasi-system", "Kubernetes namespace to install Drasi into.")
 	initCommand.Flags().String("dapr-runtime-version", "1.10.0", "Dapr runtime version to install.")
 	initCommand.Flags().String("dapr-sidecar-version", "1.9.0", "Dapr sidecar (daprd) version to install.")
+	initCommand.Flags().Bool("skip-dapr-install", false, "Skip installing Dapr runtime and sidecar.")
 	return initCommand
 }

--- a/cli/service/installer.go
+++ b/cli/service/installer.go
@@ -100,18 +100,22 @@ func MakeInstaller(namespace string) (*Installer, error) {
 	return &result, nil
 }
 
-func (t *Installer) Install(localMode bool, acr string, version string, output output.TaskOutput, namespace string) error {
-	daprInstalled, err := t.checkDaprInstallation(output)
-	if err != nil {
-		return err
-	}
-	if !daprInstalled {
-		if err = t.installDapr(output); err != nil {
+func (t *Installer) Install(localMode bool, acr string, version string, output output.TaskOutput, namespace string, skipDaprInstall bool) error {
+
+	if !skipDaprInstall {
+		daprInstalled, err := t.checkDaprInstallation(output)
+		if err != nil {
 			return err
+		}
+		if !daprInstalled {
+			if err = t.installDapr(output); err != nil {
+				return err
+			}
 		}
 	}
 
-	if err = t.createConfig(localMode, acr, version); err != nil {
+	err := t.createConfig(localMode, acr, version)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Description

Allow users to skip installing dapr in situations where it is already installed on the cluster (and may not be detected by the built in check)

## Type of change
BugFix
Fixes: #119
