### PR TITLE
Updated the release workflow to use makefiles and updated rust version in lint workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/ruokun-niu" \
+          IMAGE_PREFIX="ghcr.io/drasi-project" \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make 
 
@@ -155,7 +155,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/ruokun-niu" \
+          IMAGE_PREFIX="ghcr.io/drasi-project" \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 
@@ -258,7 +258,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/ruokun-niu" \
+          IMAGE_PREFIX="ghcr.io/drasi-project" \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 
@@ -348,7 +348,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/ruokun-niu" \
+          IMAGE_PREFIX="ghcr.io/drasi-project" \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -274,47 +274,56 @@ jobs:
           { 
             label: 'SignalR',
             path: 'reactions/signalr/signalr-reaction', 
-            name: 'reaction-signalr'
+            name: 'reaction-signalr',
+            platforms: 'linux/amd64,linux/arm64'
           },
           { 
             label: 'Dataverse',
             path: './reactions/power-platform/dataverse/dataverse-reaction', 
-            name: 'reaction-dataverse'
+            name: 'reaction-dataverse',
+            platforms: 'linux/amd64'
           },
           { 
             label: 'Debezium',
             path: './reactions/debezium/debezium-reaction', 
-            name: 'reaction-debezium'
+            name: 'reaction-debezium',
+            platforms: 'linux/amd64,linux/arm64'
           },
           { 
             label: 'Debug',
             path: './reactions/platform/debug-reaction', 
-            name: 'reaction-debug'
+            name: 'reaction-debug',
+            platforms: 'linux/amd64,linux/arm64'
           },
           { 
             label: 'EventGrid',
             path: './reactions/azure/eventgrid-reaction',
-            name: 'reaction-eventgrid'
+            name: 'reaction-eventgrid',
+            platforms: 'linux/amd64,linux/arm64'
           },
           { 
             label: 'Gremlin',
             path: './reactions/gremlin/gremlin-reaction', 
-            name: 'reaction-gremlin'
+            name: 'reaction-gremlin',
+            platforms: 'linux/amd64,linux/arm64'
           },
           { 
             label: 'Result',
             path: './reactions/platform/result-reaction', 
-            name: 'reaction-result'
+            name: 'reaction-result',
+            platforms: 'linux/amd64,linux/arm64'
           },
           { 
             label: 'StorageQueue',
             path: './reactions/azure/storagequeue-reaction', 
-            name: 'reaction-storagequeue'
+            name: 'reaction-storagequeue',
+            platforms: 'linux/amd64,linux/arm64'
           },
           { 
             label: 'StoredProc',
             path: './reactions/sql/storedproc-reaction', 
-            name: 'reaction-storedproc'
+            name: 'reaction-storedproc',
+            platforms: 'linux/amd64,linux/arm64'
           }
         ]
     steps:
@@ -349,7 +358,7 @@ jobs:
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
           IMAGE_PREFIX="ghcr.io/drasi-project" \
-          DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
+          DOCKERX_OPTS="--push --platform ${{ matrix.component.platforms }} --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 
   build-cli:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -19,7 +19,11 @@ on:
     inputs:
       tag:
         description: 'Version Tag'
-        required: true        
+        required: true      
+      image_prefix:
+        description: 'Image Prefix'
+        required: false
+        default: 'ghcr.io/drasi-project'  
 
 permissions:
   id-token: write # Required for requesting the JWT
@@ -100,7 +104,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          IMAGE_PREFIX=${{ inputs.image_prefix }} \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make 
 
@@ -155,7 +159,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          IMAGE_PREFIX=${{ inputs.image_prefix }} \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 
@@ -258,7 +262,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          IMAGE_PREFIX=${{ inputs.image_prefix }} \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 
@@ -357,7 +361,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          IMAGE_PREFIX=${{ inputs.image_prefix }} \
           DOCKERX_OPTS="--push --platform ${{ matrix.component.platforms }} --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -48,10 +48,28 @@ jobs:
       packages: write
       contents: read
     runs-on: ubuntu-latest
-
+    strategy: 
+      matrix:
+        component: [
+          { 
+            label: 'Query Host',
+            path: 'query-container/query-host', 
+            name: 'query-container-query-host'
+          },
+          { 
+            label: 'Publish API',
+            path: 'query-container/publish-api', 
+            name: 'query-container-publish-api'
+          },
+          { 
+            label: 'View Service',
+            path: 'query-container/view-svc', 
+            name: 'query-container-view-svc'
+          }
+        ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
           token: ${{ secrets.DRASI_CORE_PAT }}
@@ -70,42 +88,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Build Query Host
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+      - name: Cache Docker layers
+        uses: actions/cache@v4
         with:
-          context: ./query-container/query-host
-          file: ./query-container/query-host/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/query-container-query-host:${{ inputs.tag }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/query-host:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/query-host:cache,mode=max
-          push: true
+          path: /tmp/.buildx-cache
+          key: buildx-${{ matrix.component.name }}
+          restore-keys: |
+            buildx-${{ matrix.component.name }}
 
-      - name: Build Publish API
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          context: ./query-container/publish-api
-          file: ./query-container/publish-api/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/query-container-publish-api:${{ inputs.tag }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/publish-api:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/publish-api:cache
-          push: true
-
-      - name: Build View Service
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          context: ./query-container/view-svc
-          file: ./query-container/view-svc/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/query-container-view-svc:${{ inputs.tag }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/view-svc:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/view-svc:cache
-          push: true
+      - name: Build and Push to GHCR
+        run: |
+          cd ${{ matrix.component.path }}
+          DOCKER_TAG_VERSION=${{ inputs.tag }} \
+          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
+          make 
 
   build-control-plane:
     runs-on: ubuntu-latest
@@ -113,241 +110,18 @@ jobs:
     permissions:
       packages: write
       contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
-        with:
-          install: true
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Build Management API
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          context: '.'
-          file: ./control-planes/mgmt_api/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/api:${{ inputs.tag }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/api:cache,mode=max
-          push: true
-
-      - name: Build k8s Resource Provider
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          context: ./control-planes
-          file: ./control-planes/kubernetes_provider/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/kubernetes-provider:${{ inputs.tag }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/kubernetes-provider:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/kubernetes-provider:cache,mode=max
-          push: true
-
-  build-sources:
-    runs-on: ubuntu-latest
-    needs: validate
-    permissions:
-      packages: write
-      contents: read
     strategy:
       matrix:
         component: [
           { 
-            label: 'Change Router',
-            context: '.', 
-            file: './sources/shared/change-router/Dockerfile', 
-            name: 'source-change-router', 
-            platforms: 'linux/amd64,linux/arm64'
+            label: 'Management API',
+            path: 'control-planes/mgmt_api', 
+            name: 'api'
           },
           { 
-            label: 'Change Dispatcher',
-            context: '.', 
-            file: './sources/shared/change-dispatcher/Dockerfile', 
-            name: 'source-change-dispatcher', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Query API',
-            context: '.', 
-            file: './sources/shared/query-api/Dockerfile', 
-            name: 'source-query-api', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Debezium Reactivator',
-            context: './sources/relational/debezium-reactivator', 
-            file: './sources/relational/debezium-reactivator/Dockerfile', 
-            name: 'source-debezium-reactivator', 
-            platforms: 'linux/amd64,linux/arm64' 
-          },
-          { 
-            label: 'SQL Proxy',
-            context: './sources/relational/sql-proxy', 
-            file: './sources/relational/sql-proxy/Dockerfile', 
-            name: 'source-sql-proxy', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-
-          { 
-            label: 'CosmosDB Reactivator',
-            context: './sources/cosmosdb/cosmosdb-ffcf-reactivator', 
-            file: './sources/cosmosdb/cosmosdb-ffcf-reactivator/Dockerfile', 
-            name: 'source-cosmosdb-reactivator', 
-            platforms: 'linux/amd64,linux/arm64' 
-          },
-          { 
-            label: 'Gremlin Proxy',
-            context: './sources/cosmosdb/gremlin-proxy', 
-            file: './sources/cosmosdb/gremlin-proxy/Dockerfile', 
-            name: 'source-gremlin-proxy', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-
-          { 
-            label: 'Dataverse Reactivator',
-            context: './sources/dataverse/dataverse-reactivator', 
-            file: './sources/dataverse/dataverse-reactivator/Dockerfile', 
-            name: 'source-dataverse-reactivator', 
-            platforms: 'linux/amd64,linux/arm64' 
-          },
-          { 
-            label: 'Dataverse Proxy',
-            context: './sources/dataverse/dataverse-proxy', 
-            file: './sources/dataverse/dataverse-proxy/Dockerfile', 
-            name: 'source-dataverse-proxy', 
-            platforms: 'linux/amd64,linux/arm64' 
-          },
-
-          { 
-            label: 'EventHub Reactivator',
-            context: './sources/eventhub/eventhub-reactivator', 
-            file: './sources/eventhub/eventhub-reactivator/Dockerfile', 
-            name: 'source-eventhub-reactivator', 
-            platforms: 'linux/amd64,linux/arm64' 
-          },
-          { 
-            label: 'EventHub Proxy',
-            context: './sources/eventhub/eventhub-proxy', 
-            file: './sources/eventhub/eventhub-proxy/Dockerfile', 
-            name: 'source-eventhub-proxy', 
-            platforms: 'linux/amd64,linux/arm64' 
-          }
-        ]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
-        with:
-          install: true
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Build and push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          context: ${{ matrix.component.context }}
-          file: ${{ matrix.component.file }}
-          platforms: ${{ matrix.component.platforms }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}:${{ inputs.tag }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}:cache,mode=max
-          push: true
-
-  build-reactions:
-    needs: validate
-    permissions:
-      packages: write
-      contents: read
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        component: [
-          { 
-            label: 'SignalR',
-            context: './reactions/signalr/signalr-reaction', 
-            file: './reactions/signalr/signalr-reaction/Dockerfile', 
-            name: 'reaction-signalr', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Dataverse',
-            context: './reactions/power-platform/dataverse/dataverse-reaction', 
-            file: './reactions/power-platform/dataverse/dataverse-reaction/Dockerfile', 
-            name: 'reaction-dataverse', 
-            platforms: 'linux/amd64'
-          },
-          { 
-            label: 'Debezium',
-            context: './reactions/debezium/debezium-reaction', 
-            file: './reactions/debezium/debezium-reaction/Dockerfile', 
-            name: 'reaction-debezium', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Debug',
-            context: './reactions/platform/debug-reaction', 
-            file: './reactions/platform/debug-reaction/Dockerfile', 
-            name: 'reaction-debug', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'EventGrid',
-            context: './reactions/azure/eventgrid-reaction', 
-            file: './reactions/azure/eventgrid-reaction/Dockerfile', 
-            name: 'reaction-eventgrid', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Gremlin',
-            context: './reactions/gremlin/gremlin-reaction', 
-            file: './reactions/gremlin/gremlin-reaction/Dockerfile', 
-            name: 'reaction-gremlin', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Result',
-            context: './reactions/platform/result-reaction', 
-            file: './reactions/platform/result-reaction/Dockerfile', 
-            name: 'reaction-result', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'StorageQueue',
-            context: './reactions/azure/storagequeue-reaction', 
-            file: './reactions/azure/storagequeue-reaction/Dockerfile', 
-            name: 'reaction-storagequeue', 
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'StoredProc',
-            context: './reactions/sql/storedproc-reaction', 
-            file: './reactions/sql/storedproc-reaction/Dockerfile', 
-            name: 'reaction-storedproc', 
-            platforms: 'linux/amd64,linux/arm64'
+            label: 'k8s Resource Provider',
+            path: 'control-planes/kubernetes_provider', 
+            name: 'kubernetes-provider'
           }
         ]
     steps:
@@ -369,17 +143,215 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
      
-      - name: Build and push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+      - name: Cache Docker layers
+        uses: actions/cache@v4
         with:
-          context: ${{ matrix.component.context }}
-          file: ${{ matrix.component.file }}
-          platforms: ${{ matrix.component.platforms }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}:${{ inputs.tag }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.component.name }}:cache,mode=max
-          push: true
-  
+          path: /tmp/.buildx-cache
+          key: buildx-${{ matrix.component.name }}
+          restore-keys: |
+            buildx-${{ matrix.component.name }}
+      
+      - name: Build and Push to GHCR
+        run: |
+          cd ${{ matrix.component.path }}
+          DOCKER_TAG_VERSION=${{ inputs.tag }} \
+          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
+          make
+
+
+  build-sources:
+    runs-on: ubuntu-latest
+    needs: validate
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      matrix:
+        component: [
+          { 
+            label: 'Change Router',
+            path: 'sources/shared/change-router', 
+            name: 'source-change-router'
+          },
+          { 
+            label: 'Change Dispatcher',
+            path: 'sources/shared/change-dispatcher', 
+            name: 'source-change-dispatcher'
+          },
+          { 
+            label: 'Query API',
+            path: 'sources/shared/query-api', 
+            name: 'source-query-api' 
+          },
+          { 
+            label: 'Debezium Reactivator',
+            path: 'sources/relational/debezium-reactivator', 
+            name: 'source-debezium-reactivator'
+          },
+          { 
+            label: 'SQL Proxy',
+            path: 'sources/relational/sql-proxy', 
+            name: 'source-sql-proxy' 
+          },
+
+          { 
+            label: 'CosmosDB Reactivator',
+            path: './sources/cosmosdb/cosmosdb-ffcf-reactivator', 
+            name: 'source-cosmosdb-reactivator'
+          },
+          { 
+            label: 'Gremlin Proxy',
+            path: 'sources/cosmosdb/gremlin-proxy', 
+            name: 'source-gremlin-proxy'
+          },
+          { 
+            label: 'Dataverse Reactivator',
+            path: './sources/dataverse/dataverse-reactivator',
+            name: 'source-dataverse-reactivator'
+          },
+          { 
+            label: 'Dataverse Proxy',
+            path: './sources/dataverse/dataverse-proxy', 
+            name: 'source-dataverse-proxy'
+          },
+          { 
+            label: 'EventHub Reactivator',
+            path: './sources/eventhub/eventhub-reactivator', 
+            name: 'source-eventhub-reactivator'
+          },
+          { 
+            label: 'EventHub Proxy',
+            path: './sources/eventhub/eventhub-proxy', 
+            name: 'source-eventhub-proxy'
+          }
+        ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+        with:
+          install: true
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ matrix.component.name }}
+          restore-keys: |
+            buildx-${{ matrix.component.name }}
+
+      - name: Build and Push to GHCR
+        run: |
+          cd ${{ matrix.component.path }}
+          DOCKER_TAG_VERSION=${{ inputs.tag }} \
+          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
+          make
+
+  build-reactions:
+    needs: validate
+    permissions:
+      packages: write
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [
+          { 
+            label: 'SignalR',
+            path: 'reactions/signalr/signalr-reaction', 
+            name: 'reaction-signalr'
+          },
+          { 
+            label: 'Dataverse',
+            path: './reactions/power-platform/dataverse/dataverse-reaction', 
+            name: 'reaction-dataverse'
+          },
+          { 
+            label: 'Debezium',
+            path: './reactions/debezium/debezium-reaction', 
+            name: 'reaction-debezium'
+          },
+          { 
+            label: 'Debug',
+            path: './reactions/platform/debug-reaction', 
+            name: 'reaction-debug'
+          },
+          { 
+            label: 'EventGrid',
+            path: './reactions/azure/eventgrid-reaction',
+            name: 'reaction-eventgrid'
+          },
+          { 
+            label: 'Gremlin',
+            path: './reactions/gremlin/gremlin-reaction', 
+            name: 'reaction-gremlin'
+          },
+          { 
+            label: 'Result',
+            path: './reactions/platform/result-reaction', 
+            name: 'reaction-result'
+          },
+          { 
+            label: 'StorageQueue',
+            path: './reactions/azure/storagequeue-reaction', 
+            name: 'reaction-storagequeue'
+          },
+          { 
+            label: 'StoredProc',
+            path: './reactions/sql/storedproc-reaction', 
+            name: 'reaction-storedproc'
+          }
+        ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+        with:
+          install: true
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+     
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ matrix.component.name }}
+          restore-keys: |
+            buildx-${{ matrix.component.name }}
+
+      - name: Build and Push to GHCR
+        run: |
+          cd ${{ matrix.component.path }}
+          DOCKER_TAG_VERSION=${{ inputs.tag }} \
+          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
+          make
+
   build-cli:
     runs-on: ubuntu-latest
     needs: validate

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          IMAGE_PREFIX="ghcr.io/ruokun-niu" \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make 
 
@@ -155,7 +155,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          IMAGE_PREFIX="ghcr.io/ruokun-niu" \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 
@@ -258,7 +258,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          IMAGE_PREFIX="ghcr.io/ruokun-niu" \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 
@@ -348,7 +348,7 @@ jobs:
         run: |
           cd ${{ matrix.component.path }}
           DOCKER_TAG_VERSION=${{ inputs.tag }} \
-          IMAGE_PREFIX="ghcr.io/drasi-project" \
+          IMAGE_PREFIX="ghcr.io/ruokun-niu" \
           DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
           make
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,14 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: true
+          - name: Install specific Rust version
+          uses: actions-rs/toolchain@v1
+          with:
+            toolchain: 1.83.0 # Pin to a specific Rust version
+            override: true
+  
+        - name: Install Clippy
+          run: rustup component add clippy
 
       - name: Install protobuf-compiler
         run: sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
           override: true
 
       - name: Install Clippy
-        run: rustup component add clippy
+        run: rustup component add clippy rustfmt
 
       - name: Install protobuf-compiler
         run: sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,14 +45,14 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: true
-          - name: Install specific Rust version
-          uses: actions-rs/toolchain@v1
-          with:
-            toolchain: 1.83.0 # Pin to a specific Rust version
-            override: true
-  
-        - name: Install Clippy
-          run: rustup component add clippy
+      - name: Install specific Rust version
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.83.0 # Pin to a specific Rust version
+          override: true
+
+      - name: Install Clippy
+        run: rustup component add clippy
 
       - name: Install protobuf-compiler
         run: sudo apt-get install -y protobuf-compiler

--- a/reactions/signalr/signalr-reaction/Dockerfile
+++ b/reactions/signalr/signalr-reaction/Dockerfile
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS build
+# Need to add BUILDPLATFORM to the Dockerfile; see https://github.com/dotnet/sdk/issues/37148
+FROM --platform=$BUILDPLATFORM  mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY . .
 RUN dotnet restore
 RUN dotnet build -c $BUILD_CONFIGURATION -o /app/build
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS final
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS final
 WORKDIR /app
 COPY --from=build /app/build .
 ENTRYPOINT ["/app/Drasi.Reactions.SignalR"]


### PR DESCRIPTION
# Description

- The release workflow currently build and push multi-arch images using the Makefiles
- Set rust version to 1.83.0 in the lint workflow; this is consistent with `drasi-core`
- Updated the dockerfile of the Signalr Reaction to fix build error (This issue came up when we tried to build arm64 images in the github workflow runner)

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
