### PR TITLE
Gremlin Reaction hotfix

### DIFF
--- a/e2e-tests/03-gremlin-reaction-scenario/gremlin-reaction-duplicate.yaml
+++ b/e2e-tests/03-gremlin-reaction-scenario/gremlin-reaction-duplicate.yaml
@@ -1,0 +1,11 @@
+kind: Reaction
+apiVersion: v1
+name: e2e-gremlin-reaction-duplicate
+spec:
+  kind: Gremlin
+  queries:
+    query3:
+  properties: 
+    addedResultCommand: g.addV('Item').property('ItemName', @Name).property('Name',@Name)
+    gremlinHost: gremlin-server.default.svc.cluster.local
+    gremlinPort: 8182

--- a/e2e-tests/03-gremlin-reaction-scenario/gremlin-reaction.test.js
+++ b/e2e-tests/03-gremlin-reaction-scenario/gremlin-reaction.test.js
@@ -96,6 +96,23 @@ test('Test Gremlin Reaction - deletedResultCommand', async () => {
 }, 140000);
 
 
+test('Test Gremlin Reaction - addedResultCommand with duplicate parameters', async () => {
+  const gremlinReaction = yaml.loadAll(fs.readFileSync(__dirname + '/gremlin-reaction-duplicate.yaml', 'utf8'));
+  await deployResources(gremlinReaction);
+
+  await postgresClient.query(`INSERT INTO "Item" ("ItemId", "Name", "Category") VALUES (5, 'Drasi', '3')`);
+  await waitForCondition(async () => {
+    const result = await gremlinClient.V().has('ItemName', 'Drasi').hasNext();
+    return result;
+  }, 1000,30000)
+  .then(() => {
+    expect(true).toBeTruthy(); 
+  })
+  .catch(() => {
+    expect(false).toBeTruthy();
+  });
+}, 140000);
+
 afterAll(async () => {
   await postgresClient.end();
   postgresPortForward.stop();
@@ -116,6 +133,7 @@ afterAll(async () => {
   const gremlinReactionDeletion = yaml.loadAll(fs.readFileSync(__dirname + '/gremlin-reaction-deletion.yaml', 'utf8'));
   await deleteResources(gremlinReactionDeletion);
 });
+
 
 
 function waitForCondition(checkFn, interval = 1000, timeout = 30000) {

--- a/e2e-tests/03-gremlin-reaction-scenario/resources.yaml
+++ b/e2e-tests/03-gremlin-reaction-scenario/resources.yaml
@@ -120,3 +120,19 @@ spec:
       i.ItemId AS Id, 
       i.Name as Name,
       i.Category as Category
+---
+apiVersion: v1
+kind: ContinuousQuery
+name: query4
+spec:
+  mode: query
+  sources:    
+    subscriptions:
+      - id: test-source-3
+  query: > 
+    MATCH 
+      (i:Item {Category: '5'})
+    RETURN 
+      i.ItemId AS Id, 
+      i.Name as Name,
+      i.Category as Category

--- a/reactions/gremlin/gremlin-reaction/Dockerfile
+++ b/reactions/gremlin/gremlin-reaction/Dockerfile
@@ -15,14 +15,14 @@
 
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY . . 
 RUN dotnet restore
 RUN dotnet build -c $BUILD_CONFIGURATION -o /app/build
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS final
 WORKDIR /app
 COPY --from=build /app/build .
 ENTRYPOINT ["/app/gremlin-reaction"]

--- a/reactions/gremlin/gremlin-reaction/Services/GremlinService.cs
+++ b/reactions/gremlin/gremlin-reaction/Services/GremlinService.cs
@@ -138,6 +138,11 @@ namespace Drasi.Reactions.Gremlin.Services {
 
         public void ProcessAddedQueryResults(Dictionary<string, object> res)
         {
+            if (_addedResultCommand == null)
+            {
+                _logger.LogInformation("No Deleted Result Command Specified");
+                return;
+            }
             string newCmd = _addedResultCommand;
 
             // Dictionary to hold the parameters for the command
@@ -149,6 +154,11 @@ namespace Drasi.Reactions.Gremlin.Services {
                 // Prepare the parameterized query by removing the @ sign
                 newCmd = newCmd.Replace($"@{param}", param);
                 var queryResultValue = ExtractQueryResultValue(param, res);
+                if (addedResultCommandParams.ContainsKey(param))
+                {
+                    _logger.LogInformation($"Parameter {param} already exists. Skipping.");
+                    continue;
+                }
                 addedResultCommandParams.Add(param, queryResultValue);
             }
             _logger.LogInformation($"Issuing added result command: {newCmd}");
@@ -168,6 +178,11 @@ namespace Drasi.Reactions.Gremlin.Services {
 
         public void ProcessUpdatedQueryResults(UpdatedResultElement updatedResult)
         {
+            if (_updatedResultCommand == null)
+            {
+                _logger.LogInformation("No Deleted Result Command Specified");
+                return;
+            }
             _logger.LogInformation($"Updated Result {updatedResult}");
 
             string newCmd = _updatedResultCommand;
@@ -180,18 +195,33 @@ namespace Drasi.Reactions.Gremlin.Services {
                 {
                     // Prepare the parameterized query by removing the @ sign
                     newCmd = newCmd.Replace($"@{param}", param);
+                    if (updatedResultCommandParams.ContainsKey(param))
+                    {
+                        _logger.LogInformation($"Parameter {param} already exists. Skipping.");
+                        continue;
+                    }
                     updatedResultCommandParams.Add(param, ExtractQueryResultValue(param.Substring(7), updatedResult.Before));
                 }
                 else if (param.StartsWith("after."))
                 {
                     // Prepare the parameterized query by removing the @ sign
                     newCmd = newCmd.Replace($"@{param}", param);
+                    if (updatedResultCommandParams.ContainsKey(param))
+                    {
+                        _logger.LogInformation($"Parameter {param} already exists. Skipping.");
+                        continue;
+                    }
                     updatedResultCommandParams.Add(param, ExtractQueryResultValue(param.Substring(6), updatedResult.After));
                 }
                 else
                 {
                     // Prepare the parameterized query by removing the @ sign
                     newCmd = newCmd.Replace($"@{param}", param);
+                    if (updatedResultCommandParams.ContainsKey(param))
+                    {
+                        _logger.LogInformation($"Parameter {param} already exists. Skipping.");
+                        continue;
+                    }
                     updatedResultCommandParams.Add(param, ExtractQueryResultValue(param, updatedResult.After));
                 }
             }
@@ -212,6 +242,11 @@ namespace Drasi.Reactions.Gremlin.Services {
 
         public void ProcessDeletedQueryResults(Dictionary<string, object> deletedResults)
         {
+            if (_deletedResultCommand == null)
+            {
+                _logger.LogInformation("No Deleted Result Command Specified");
+                return;
+            }
             _logger.LogInformation($"Deleted Result {deletedResults}");
 
             string newCmd = _deletedResultCommand;
@@ -222,6 +257,11 @@ namespace Drasi.Reactions.Gremlin.Services {
             {
                 // Prepare the parameterized query by removing the @ sign
                 newCmd = newCmd.Replace($"@{param}", param);
+                if (deletedResultCommandParams.ContainsKey(param))
+                {
+                    _logger.LogInformation($"Parameter {param} already exists. Skipping.");
+                    continue;
+                }
                 deletedResultCommandParams.Add(param, ExtractQueryResultValue(param, deletedResults));
             }
             _logger.LogInformation($"Issuing deleted result command: {newCmd}");


### PR DESCRIPTION
# Description

Improved the following areas in the Gremlin Reaction:
- If the same parameter name is used multiple times in a single Gremlin command (for example `g.addV('Item').property('ItemName', @Name).property('Name',@Name)`), an exception will be thrown. I have added a check to catch this
- When a certain type of result is received (e.g. DeletedResults), even if the user has not supplied a Gremlin command for that type, the Gremlin client will still attempt to execute the null command
- Added a test for this scenario

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
