### PR TITLE
Init logging for change-router & change-dispatcher

### DIFF
--- a/sources/shared/change-dispatcher/src/main.rs
+++ b/sources/shared/change-dispatcher/src/main.rs
@@ -38,6 +38,7 @@ mod change_dispatcher_config;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     info!("Starting Source Change Dispatcher");
 
     let config = ChangeDispatcherConfig::new();

--- a/sources/shared/change-router/src/main.rs
+++ b/sources/shared/change-router/src/main.rs
@@ -39,6 +39,7 @@ mod subscribers;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     log::info!("Starting Source Change Router");
 
     let config = ChangeRouterConfig::from_env();


### PR DESCRIPTION
# Description

The logging for `change-router` and `change-dispatcher` is not initialized, so we do not get any logs.
