### PR TITLE
Transition to Native Multi-Platform Builds for Docker Images

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -349,7 +349,7 @@ jobs:
           go-version: '1.21'
 
       - name: Cache Go modules
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -19,21 +19,81 @@ on:
     inputs:
       tag:
         description: 'Version Tag'
-        required: true      
+        required: true
       image_prefix:
         description: 'Image Prefix'
         required: false
-        default: 'ghcr.io/drasi-project'  
+        default: 'ghcr.io/drasi-project'
 
 permissions:
-  id-token: write # Required for requesting the JWT
-  contents: read  # Required for actions/checkout
-  packages: read
+  id-token: write
+  contents: read
+  packages: write
 
+# Environment variables with consistent `platforms` fields
 env:
   RELEASE_PATH: ./release
 
+  QUERY_COMPONENTS: '[
+    {"label": "Query Host", "path": "query-container/query-host", "name": "query-container-query-host", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Publish API", "path": "query-container/publish-api", "name": "query-container-publish-api", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "View Service", "path": "query-container/view-svc", "name": "query-container-view-svc", "platforms": "linux/amd64,linux/arm64"}]'
+
+  CONTROL_PLANE_COMPONENTS: '[
+    {"label": "Management API", "path": "control-planes/mgmt_api", "name": "api", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "k8s Resource Provider", "path": "control-planes/kubernetes_provider", "name": "kubernetes-provider", "platforms": "linux/amd64,linux/arm64"}]'
+  
+  SOURCES_COMPONENTS: '[
+    {"label": "Change Router", "path": "sources/shared/change-router", "name": "source-change-router", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Change Dispatcher", "path": "sources/shared/change-dispatcher", "name": "source-change-dispatcher", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Query API", "path": "sources/shared/query-api", "name": "source-query-api", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Debezium Reactivator", "path": "sources/relational/debezium-reactivator", "name": "source-debezium-reactivator", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "SQL Proxy", "path": "sources/relational/sql-proxy", "name": "source-sql-proxy", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "CosmosDB Reactivator", "path": "sources/cosmosdb/cosmosdb-ffcf-reactivator", "name": "source-cosmosdb-reactivator", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Gremlin Proxy", "path": "sources/cosmosdb/gremlin-proxy", "name": "source-gremlin-proxy", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Dataverse Reactivator", "path": "sources/dataverse/dataverse-reactivator", "name": "source-dataverse-reactivator", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Dataverse Proxy", "path": "sources/dataverse/dataverse-proxy", "name": "source-dataverse-proxy", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "EventHub Reactivator", "path": "sources/eventhub/eventhub-reactivator", "name": "source-eventhub-reactivator", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "EventHub Proxy", "path": "sources/eventhub/eventhub-proxy", "name": "source-eventhub-proxy", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Kubernetes Reactivator", "path": "sources/kubernetes/kubernetes-reactivator", "name": "source-kubernetes-reactivator", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Kubernetes Proxy", "path": "sources/kubernetes/kubernetes-proxy", "name": "source-kubernetes-proxy", "platforms": "linux/amd64,linux/arm64"}]'
+  
+  REACTIONS_COMPONENTS: '[
+    {"label": "SignalR", "path": "reactions/signalr/signalr-reaction", "name": "reaction-signalr", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Dataverse", "path": "reactions/power-platform/dataverse/dataverse-reaction", "name": "reaction-dataverse", "platforms": "linux/amd64"},
+    {"label": "Debezium", "path": "reactions/debezium/debezium-reaction", "name": "reaction-debezium", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Debug", "path": "reactions/platform/debug-reaction", "name": "reaction-debug", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "EventGrid", "path": "reactions/azure/eventgrid-reaction", "name": "reaction-eventgrid", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Gremlin", "path": "reactions/gremlin/gremlin-reaction", "name": "reaction-gremlin", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "Result", "path": "reactions/platform/result-reaction", "name": "reaction-result", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "StorageQueue", "path": "reactions/azure/storagequeue-reaction", "name": "reaction-storagequeue", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "StoredProc", "path": "reactions/sql/storedproc-reaction", "name": "reaction-storedproc", "platforms": "linux/amd64,linux/arm64"}]'
+
 jobs:
+  # Setup job to parse and output component JSON
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      query_components: ${{ steps.set_components.outputs.query_components }}
+      control_plane_components: ${{ steps.set_components.outputs.control_plane_components }}
+      sources_components: ${{ steps.set_components.outputs.sources_components }}
+      reactions_components: ${{ steps.set_components.outputs.reactions_components }}
+    steps:
+      - name: Set Component Outputs
+        id: set_components
+        run: |
+          echo "query_components=$(echo '${{ env.QUERY_COMPONENTS }}' | jq -c .)" >> $GITHUB_OUTPUT
+          echo "control_plane_components=$(echo '${{ env.CONTROL_PLANE_COMPONENTS }}' | jq -c .)" >> $GITHUB_OUTPUT
+          echo "sources_components=$(echo '${{ env.SOURCES_COMPONENTS }}' | jq -c .)" >> $GITHUB_OUTPUT
+          echo "reactions_components=$(echo '${{ env.REACTIONS_COMPONENTS }}' | jq -c .)" >> $GITHUB_OUTPUT
+      - name: Debug Outputs
+        run: |
+          echo "Query Components: ${{ steps.set_components.outputs.query_components }}"
+          echo "Control Plane Components: ${{ steps.set_components.outputs.control_plane_components }}"
+          echo "Sources Components: ${{ steps.set_components.outputs.sources_components }}"
+          echo "Reactions Components: ${{ steps.set_components.outputs.reactions_components }}"
+  
+  # Validate the branch name
   validate:
     runs-on: ubuntu-latest
     steps:
@@ -46,41 +106,24 @@ jobs:
             exit 1
           fi
 
+  # Build job for Query components
   build-query-container:
-    needs: validate
+    needs: [validate, setup]
     permissions:
       packages: write
       contents: read
-    runs-on: ubuntu-latest
-    strategy: 
+    runs-on: ${{ matrix.runner }}
+    strategy:
       matrix:
-        component: [
-          { 
-            label: 'Query Host',
-            path: 'query-container/query-host', 
-            name: 'query-container-query-host'
-          },
-          { 
-            label: 'Publish API',
-            path: 'query-container/publish-api', 
-            name: 'query-container-publish-api'
-          },
-          { 
-            label: 'View Service',
-            path: 'query-container/view-svc', 
-            name: 'query-container-view-svc'
-          }
-        ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        component: ${{ fromJson(needs.setup.outputs.query_components) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: true
           token: ${{ secrets.DRASI_CORE_PAT }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
         with:
@@ -92,48 +135,106 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-${{ matrix.component.name }}
-          restore-keys: |
-            buildx-${{ matrix.component.name }}
+
+      - name: Determine platform and tag suffix
+        id: platform
+        run: |
+          if [[ "${{ matrix.runner }}" == "ubuntu-latest" ]]; then
+            echo "platform=linux/amd64" >> $GITHUB_OUTPUT
+            echo "suffix=-amd64" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.runner }}" == "ubuntu-24.04-arm" ]]; then
+            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
+            echo "suffix=-arm64" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build and Push to GHCR
+        if: contains(matrix.component.platforms, steps.platform.outputs.platform)
         run: |
           cd ${{ matrix.component.path }}
-          DOCKER_TAG_VERSION=${{ inputs.tag }} \
+          DOCKER_TAG_VERSION=${{ inputs.tag }}${{ steps.platform.outputs.suffix }} \
           IMAGE_PREFIX=${{ inputs.image_prefix }} \
-          DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
-          make 
+          DOCKERX_OPTS="--push --platform ${{ steps.platform.outputs.platform }}" \
+          make
+  
+  # Manifest creation for Query Container components
+  create-query-container-manifest:
+    needs: build-query-container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create and push manifest list
+        run: |
+          for component in $(echo '${{ env.QUERY_COMPONENTS }}' | jq -r '.[].name'); do
+            
+            # Initialize an array to hold the manifests
+            manifests=()
+
+            # Get the expected platforms for the component as stored in JSON
+            expected_platforms=$(echo '${{ env.QUERY_COMPONENTS }}' | jq -r ".[] | select(.name == \"$component\") | .platforms")
+
+            # Does this component need to be built for linux/amd64?
+            if echo "$expected_platforms" | grep -q "linux/amd64"; then
+              
+              # Check if the amd64 manifest exists and add it to the array
+              if docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64 > /dev/null 2>&1; then
+                echo "Manifest for $component:${{ inputs.tag }}-amd64:"
+                docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64
+                manifests+=("ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64")
+              
+              # If the amd64 manifest is not found, print an error message
+              else
+                echo "Error: Expected amd64 manifest not found for $component:${{ inputs.tag }}-amd64" >&2
+                exit 1
+              fi
+            fi
+
+            # Does this component need to be built for linux/arm64?
+            if echo "$expected_platforms" | grep -q "linux/arm64"; then
+
+              # Check and handle arm64 manifest with debug output
+              if docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64 > /dev/null 2>&1; then
+                echo "Manifest for $component:${{ inputs.tag }}-arm64:"
+                docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64
+                manifests+=("ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64")
+              
+              # If the arm64 manifest is not found, print an error message
+              else
+                echo "Error: Expected arm64 manifest found for $component:${{ inputs.tag }}-arm64" >&2
+                exit 1
+              fi
+            fi
+            
+            # Create the manifest list if there are manifests to combine
+            if [ ${#manifests[@]} -gt 0 ]; then
+              docker buildx imagetools create -t ghcr.io/drasi-project/$component:${{ inputs.tag }} ${manifests[@]}
+            else
+              echo "No manifests found for $component, skipping manifest creation."
+            fi
+          done
+
+  # Build job for Control Plane components
   build-control-plane:
-    runs-on: ubuntu-latest
-    needs: validate
+    needs: [validate, setup]
     permissions:
       packages: write
       contents: read
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        component: [
-          { 
-            label: 'Management API',
-            path: 'control-planes/mgmt_api', 
-            name: 'api'
-          },
-          { 
-            label: 'k8s Resource Provider',
-            path: 'control-planes/kubernetes_provider', 
-            name: 'kubernetes-provider'
-          }
-        ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        component: ${{ fromJson(needs.setup.outputs.control_plane_components) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+        with:
+          submodules: true
+          token: ${{ secrets.DRASI_CORE_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
@@ -146,107 +247,88 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-     
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-${{ matrix.component.name }}
-          restore-keys: |
-            buildx-${{ matrix.component.name }}
-      
+
+      - name: Determine platform and tag suffix
+        id: platform
+        run: |
+          if [[ "${{ matrix.runner }}" == "ubuntu-latest" ]]; then
+            echo "platform=linux/amd64" >> $GITHUB_OUTPUT
+            echo "suffix=-amd64" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.runner }}" == "ubuntu-24.04-arm" ]]; then
+            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
+            echo "suffix=-arm64" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and Push to GHCR
+        if: contains(matrix.component.platforms, steps.platform.outputs.platform)
         run: |
           cd ${{ matrix.component.path }}
-          DOCKER_TAG_VERSION=${{ inputs.tag }} \
+          DOCKER_TAG_VERSION=${{ inputs.tag }}${{ steps.platform.outputs.suffix }} \
           IMAGE_PREFIX=${{ inputs.image_prefix }} \
-          DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
+          DOCKERX_OPTS="--push --platform ${{ steps.platform.outputs.platform }}" \
           make
 
+  # Manifest creation for Control Plane components
+  create-control-plane-manifest:
+    needs: build-control-plane
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create and push manifest list
+        run: |
+          for component in $(echo '${{ env.CONTROL_PLANE_COMPONENTS }}' | jq -r '.[].name'); do
+            manifests=()
+
+            # Check and handle amd64 manifest with debug output
+            if docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64 > /dev/null 2>&1; then
+              echo "Manifest for $component:${{ inputs.tag }}-amd64:"
+              docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64
+              manifests+=("ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64")
+            else
+              echo "No amd64 manifest found for $component:${{ inputs.tag }}-amd64"
+            fi
+            
+            # Check and handle arm64 manifest with debug output
+            if docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64 > /dev/null 2>&1; then
+              echo "Manifest for $component:${{ inputs.tag }}-arm64:"
+              docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64
+              manifests+=("ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64")
+            else
+              echo "No arm64 manifest found for $component:${{ inputs.tag }}-arm64"
+            fi
+            
+            # Create the manifest list if there are manifests to combine
+            if [ ${#manifests[@]} -gt 0 ]; then
+              docker buildx imagetools create -t ghcr.io/drasi-project/$component:${{ inputs.tag }} ${manifests[@]}
+            else
+              echo "No manifests found for $component, skipping manifest creation."
+            fi
+          
+          done
+  
+  # Build job for Sources components
   build-sources:
-    runs-on: ubuntu-latest
-    needs: validate
+    needs: [validate, setup]
     permissions:
       packages: write
       contents: read
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        component: [
-          { 
-            label: 'Change Router',
-            path: 'sources/shared/change-router', 
-            name: 'source-change-router'
-          },
-          { 
-            label: 'Change Dispatcher',
-            path: 'sources/shared/change-dispatcher', 
-            name: 'source-change-dispatcher'
-          },
-          { 
-            label: 'Query API',
-            path: 'sources/shared/query-api', 
-            name: 'source-query-api' 
-          },
-          { 
-            label: 'Debezium Reactivator',
-            path: 'sources/relational/debezium-reactivator', 
-            name: 'source-debezium-reactivator'
-          },
-          { 
-            label: 'SQL Proxy',
-            path: 'sources/relational/sql-proxy', 
-            name: 'source-sql-proxy' 
-          },
-
-          { 
-            label: 'CosmosDB Reactivator',
-            path: './sources/cosmosdb/cosmosdb-ffcf-reactivator', 
-            name: 'source-cosmosdb-reactivator'
-          },
-          { 
-            label: 'Gremlin Proxy',
-            path: 'sources/cosmosdb/gremlin-proxy', 
-            name: 'source-gremlin-proxy'
-          },
-          { 
-            label: 'Dataverse Reactivator',
-            path: './sources/dataverse/dataverse-reactivator',
-            name: 'source-dataverse-reactivator'
-          },
-          { 
-            label: 'Dataverse Proxy',
-            path: './sources/dataverse/dataverse-proxy', 
-            name: 'source-dataverse-proxy'
-          },
-          { 
-            label: 'EventHub Reactivator',
-            path: './sources/eventhub/eventhub-reactivator', 
-            name: 'source-eventhub-reactivator'
-          },
-          { 
-            label: 'EventHub Proxy',
-            path: './sources/eventhub/eventhub-proxy', 
-            name: 'source-eventhub-proxy'
-          },
-          { 
-            label: 'Kubernetes Reactivator',
-            path: './sources/kubernetes/kubernetes-reactivator', 
-            name: 'source-kubernetes-reactivator'
-          },
-          { 
-            label: 'Kubernetes Proxy',
-            path: './sources/kubernetes/kubernetes-proxy', 
-            name: 'source-kubernetes-proxy'
-          }
-        ]
-
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        component: ${{ fromJson(needs.setup.outputs.sources_components) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+        with:
+          submodules: true
+          token: ${{ secrets.DRASI_CORE_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
@@ -260,92 +342,87 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-${{ matrix.component.name }}
-          restore-keys: |
-            buildx-${{ matrix.component.name }}
+      - name: Determine platform and tag suffix
+        id: platform
+        run: |
+          if [[ "${{ matrix.runner }}" == "ubuntu-latest" ]]; then
+            echo "platform=linux/amd64" >> $GITHUB_OUTPUT
+            echo "suffix=-amd64" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.runner }}" == "ubuntu-24.04-arm" ]]; then
+            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
+            echo "suffix=-arm64" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build and Push to GHCR
+        if: contains(matrix.component.platforms, steps.platform.outputs.platform)
         run: |
           cd ${{ matrix.component.path }}
-          DOCKER_TAG_VERSION=${{ inputs.tag }} \
+          DOCKER_TAG_VERSION=${{ inputs.tag }}${{ steps.platform.outputs.suffix }} \
           IMAGE_PREFIX=${{ inputs.image_prefix }} \
-          DOCKERX_OPTS="--push --platform linux/amd64,linux/arm64 --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
+          DOCKERX_OPTS="--push --platform ${{ steps.platform.outputs.platform }}" \
           make
 
+  # Manifest creation for Sources components
+  create-sources-manifest:
+    needs: build-sources
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest list
+        run: |
+          for component in $(echo '${{ env.SOURCES_COMPONENTS }}' | jq -r '.[].name'); do
+            manifests=()
+            
+            # Check and handle amd64 manifest with debug output
+            if docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64 > /dev/null 2>&1; then
+              echo "Manifest for $component:${{ inputs.tag }}-amd64:"
+              docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64
+              manifests+=("ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64")
+            else
+              echo "No amd64 manifest found for $component:${{ inputs.tag }}-amd64"
+            fi
+            
+            # Check and handle arm64 manifest with debug output
+            if docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64 > /dev/null 2>&1; then
+              echo "Manifest for $component:${{ inputs.tag }}-arm64:"
+              docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64
+              manifests+=("ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64")
+            else
+              echo "No arm64 manifest found for $component:${{ inputs.tag }}-arm64"
+            fi
+            
+            # Create the manifest list if there are manifests to combine
+            if [ ${#manifests[@]} -gt 0 ]; then
+              docker buildx imagetools create -t ghcr.io/drasi-project/$component:${{ inputs.tag }} ${manifests[@]}
+            else
+              echo "No manifests found for $component, skipping manifest creation."
+            fi
+
+          done
+  
+  # Build job for Reactions components
   build-reactions:
-    needs: validate
+    needs: [validate, setup]
     permissions:
       packages: write
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        component: [
-          { 
-            label: 'SignalR',
-            path: 'reactions/signalr/signalr-reaction', 
-            name: 'reaction-signalr',
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Dataverse',
-            path: './reactions/power-platform/dataverse/dataverse-reaction', 
-            name: 'reaction-dataverse',
-            platforms: 'linux/amd64'
-          },
-          { 
-            label: 'Debezium',
-            path: './reactions/debezium/debezium-reaction', 
-            name: 'reaction-debezium',
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Debug',
-            path: './reactions/platform/debug-reaction', 
-            name: 'reaction-debug',
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'EventGrid',
-            path: './reactions/azure/eventgrid-reaction',
-            name: 'reaction-eventgrid',
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Gremlin',
-            path: './reactions/gremlin/gremlin-reaction', 
-            name: 'reaction-gremlin',
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'Result',
-            path: './reactions/platform/result-reaction', 
-            name: 'reaction-result',
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'StorageQueue',
-            path: './reactions/azure/storagequeue-reaction', 
-            name: 'reaction-storagequeue',
-            platforms: 'linux/amd64,linux/arm64'
-          },
-          { 
-            label: 'StoredProc',
-            path: './reactions/sql/storedproc-reaction', 
-            name: 'reaction-storedproc',
-            platforms: 'linux/amd64,linux/arm64'
-          }
-        ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+        component: ${{ fromJson(needs.setup.outputs.reactions_components) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+        with:
+          submodules: true
+          token: ${{ secrets.DRASI_CORE_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
@@ -358,23 +435,71 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-     
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-${{ matrix.component.name }}
-          restore-keys: |
-            buildx-${{ matrix.component.name }}
+
+      - name: Determine platform and tag suffix
+        id: platform
+        run: |
+          if [[ "${{ matrix.runner }}" == "ubuntu-latest" ]]; then
+            echo "platform=linux/amd64" >> $GITHUB_OUTPUT
+            echo "suffix=-amd64" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.runner }}" == "ubuntu-24.04-arm" ]]; then
+            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
+            echo "suffix=-arm64" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build and Push to GHCR
+        if: contains(matrix.component.platforms, steps.platform.outputs.platform)
         run: |
           cd ${{ matrix.component.path }}
-          DOCKER_TAG_VERSION=${{ inputs.tag }} \
+          DOCKER_TAG_VERSION=${{ inputs.tag }}${{ steps.platform.outputs.suffix }} \
           IMAGE_PREFIX=${{ inputs.image_prefix }} \
-          DOCKERX_OPTS="--push --platform ${{ matrix.component.platforms }} --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" \
+          DOCKERX_OPTS="--push --platform ${{ steps.platform.outputs.platform }}" \
           make
 
+  # Manifest creation for Reactions components
+  create-reactions-manifest:
+    needs: build-reactions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest list
+        run: |
+          for component in $(echo '${{ env.REACTIONS_COMPONENTS }}' | jq -r '.[].name'); do
+            manifests=()
+
+            # Check and handle amd64 manifest with debug output
+            if docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64 > /dev/null 2>&1; then
+              echo "Manifest for $component:${{ inputs.tag }}-amd64:"
+              docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64
+              manifests+=("ghcr.io/drasi-project/$component:${{ inputs.tag }}-amd64")
+            else
+              echo "No amd64 manifest found for $component:${{ inputs.tag }}-amd64"
+            fi
+            
+            # Check and handle arm64 manifest with debug output
+            if docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64 > /dev/null 2>&1; then
+              echo "Manifest for $component:${{ inputs.tag }}-arm64:"
+              docker manifest inspect ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64
+              manifests+=("ghcr.io/drasi-project/$component:${{ inputs.tag }}-arm64")
+            else
+              echo "No arm64 manifest found for $component:${{ inputs.tag }}-arm64"
+            fi
+            
+            # Create the manifest list if there are manifests to combine
+            if [ ${#manifests[@]} -gt 0 ]; then
+              docker buildx imagetools create -t ghcr.io/drasi-project/$component:${{ inputs.tag }} ${manifests[@]}
+            else
+              echo "No manifests found for $component, skipping manifest creation."
+            fi
+          
+          done
+  
   build-cli:
     runs-on: ubuntu-latest
     needs: validate
@@ -436,7 +561,7 @@ jobs:
         run: |
           mkdir -p ${{ env.RELEASE_PATH}}/cli/${{ matrix.os }}-${{ matrix.arch }}/
           cp -r ${{ matrix.os }}-${{ matrix.arch }}/drasi ${{ env.RELEASE_PATH}}/drasi-${{ matrix.os }}-${{ matrix.arch }}
-      - name: Copy cli binaries to release (non-windows)
+      - name: Copy cli binaries to release (windows)
         if: matrix.os == 'windows'
         run: |
           mkdir -p ${{ env.RELEASE_PATH}}/cli/${{ matrix.os }}-${{ matrix.arch }}/
@@ -472,8 +597,9 @@ jobs:
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: drasi_vscode_extension
-          path: ${{ env.RELEASE_PATH}}
-   
+          path: ${{ env.RELEASE_PATH}}/drasi-*.vsix
+
+  # Final release job
   release:
     permissions:
       contents: write
@@ -483,17 +609,17 @@ jobs:
     name: Draft Release
     needs:
       - validate
-      - build-sources
-      - build-query-container
-      - build-reactions
-      - build-control-plane
-      - package-cli      
+      - create-query-container-manifest
+      - create-control-plane-manifest
+      - create-sources-manifest
+      - create-reactions-manifest
+      - package-cli
       - vscode-extension
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7 
+      
       - name: Download CLI release
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
@@ -505,7 +631,6 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: drasi_vscode_extension
-          merge-multiple: true
           path: ${{ env.RELEASE_PATH }}
 
       - name: Draft Release

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -64,6 +64,7 @@ env:
     {"label": "Debezium", "path": "reactions/debezium/debezium-reaction", "name": "reaction-debezium", "platforms": "linux/amd64,linux/arm64"},
     {"label": "Debug", "path": "reactions/platform/debug-reaction", "name": "reaction-debug", "platforms": "linux/amd64,linux/arm64"},
     {"label": "EventGrid", "path": "reactions/azure/eventgrid-reaction", "name": "reaction-eventgrid", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "EventBridge", "path": "reactions/aws/eventbridge-reaction", "name": "reaction-eventbridge", "platforms": "linux/amd64,linux/arm64"},
     {"label": "Gremlin", "path": "reactions/gremlin/gremlin-reaction", "name": "reaction-gremlin", "platforms": "linux/amd64,linux/arm64"},
     {"label": "Result", "path": "reactions/platform/result-reaction", "name": "reaction-result", "platforms": "linux/amd64,linux/arm64"},
     {"label": "StorageQueue", "path": "reactions/azure/storagequeue-reaction", "name": "reaction-storagequeue", "platforms": "linux/amd64,linux/arm64"},
@@ -232,9 +233,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          submodules: true
-          token: ${{ secrets.DRASI_CORE_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
@@ -326,9 +324,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          submodules: true
-          token: ${{ secrets.DRASI_CORE_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
@@ -420,9 +415,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          submodules: true
-          token: ${{ secrets.DRASI_CORE_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -505,7 +505,7 @@ jobs:
           go-version: '1.21'
 
       - name: Cache Go modules
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:
           path: |
             ~/go/pkg/mod

--- a/control-planes/kubernetes_provider/Dockerfile
+++ b/control-planes/kubernetes_provider/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder 
-# rust:1.81-bullseye
+FROM rust:1.84-bullseye as builder
 RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev
 
 WORKDIR /usr/src

--- a/control-planes/kubernetes_provider/Dockerfile
+++ b/control-planes/kubernetes_provider/Dockerfile
@@ -25,7 +25,6 @@ RUN cargo fetch
 COPY ./kubernetes_provider .
 RUN cargo install --force --path .
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 COPY --from=builder /usr/local/cargo/bin/kubernetes_provider /usr/local/bin/kubernetes_provider
 CMD ["kubernetes_provider"]

--- a/control-planes/mgmt_api/Dockerfile
+++ b/control-planes/mgmt_api/Dockerfile
@@ -26,7 +26,6 @@ RUN cargo fetch
 COPY ./control-planes/mgmt_api .
 RUN cargo install --force --path .
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 COPY --from=builder /usr/local/cargo/bin/mgmt_api /usr/local/bin/mgmt_api
 CMD ["mgmt_api"]

--- a/query-container/publish-api/Dockerfile
+++ b/query-container/publish-api/Dockerfile
@@ -20,8 +20,7 @@ COPY . .
 WORKDIR /usr/src
 RUN cargo install --force --path .
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/publish-api /usr/local/bin/publish-api
 CMD ["publish-api"]

--- a/query-container/publish-api/Dockerfile
+++ b/query-container/publish-api/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM rust:1.84-bullseye as builder
-RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev
+RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev libcurl4 && apt-get clean
 
 WORKDIR /usr/src
 COPY . .

--- a/query-container/query-host/Dockerfile
+++ b/query-container/query-host/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
-# rust:1.81-bullseye
+FROM rust:1.84-bullseye as builder
 RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev
 
 WORKDIR /usr/src

--- a/query-container/query-host/Dockerfile
+++ b/query-container/query-host/Dockerfile
@@ -20,8 +20,7 @@ COPY . .
 WORKDIR /usr/src
 RUN cargo install --path .
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/query-host /usr/local/bin/query-host
 CMD ["query-host"]

--- a/query-container/view-svc/Dockerfile
+++ b/query-container/view-svc/Dockerfile
@@ -20,8 +20,7 @@ COPY . .
 WORKDIR /usr/src
 RUN cargo install --force --path .
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/view-svc /usr/local/bin/view-svc
 CMD ["view-svc"]

--- a/query-container/view-svc/Dockerfile
+++ b/query-container/view-svc/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
-# rust:1.81-bullseye
+FROM rust:1.84-bullseye as builder
 RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev
 
 WORKDIR /usr/src
@@ -21,8 +20,8 @@ COPY . .
 WORKDIR /usr/src
 RUN cargo install --force --path .
 
-FROM gcr.io/distroless/cc@sha256:3b75fdd33932d16e53a461277becf57c4f815c6cee5f6bc8f52457c095e004c8
-# gcr.io/distroless/cc 
+FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
+# gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/view-svc /usr/local/bin/view-svc
 CMD ["view-svc"]

--- a/sources/kubernetes/kubernetes-proxy/Dockerfile
+++ b/sources/kubernetes/kubernetes-proxy/Dockerfile
@@ -6,8 +6,7 @@ COPY . .
 WORKDIR /usr/src
 RUN cargo install --force --path .
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/kubernetes-proxy /usr/local/bin/kubernetes-proxy
 CMD ["kubernetes-proxy"]

--- a/sources/kubernetes/kubernetes-proxy/Dockerfile
+++ b/sources/kubernetes/kubernetes-proxy/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
-# rust:1.81-bullseye
+FROM rust:1.84-bullseye as builder
 RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && apt-get clean
 
 WORKDIR /usr/src

--- a/sources/kubernetes/kubernetes-reactivator/Dockerfile
+++ b/sources/kubernetes/kubernetes-reactivator/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
-# rust:1.81-bullseye
+FROM rust:1.84-bullseye as builder
 RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && apt-get clean
 
 WORKDIR /usr/src

--- a/sources/kubernetes/kubernetes-reactivator/Dockerfile
+++ b/sources/kubernetes/kubernetes-reactivator/Dockerfile
@@ -6,8 +6,7 @@ COPY . .
 WORKDIR /usr/src
 RUN cargo install --force --path .
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/kubernetes-reactivator /usr/local/bin/kubernetes-reactivator
 CMD ["kubernetes-reactivator"]

--- a/sources/sdk/rust/example/proxy/Dockerfile
+++ b/sources/sdk/rust/example/proxy/Dockerfile
@@ -6,8 +6,7 @@ COPY . .
 WORKDIR /usr/src
 RUN cargo install --force --path .
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/proxy /usr/local/bin/proxy
 CMD ["proxy"]

--- a/sources/sdk/rust/example/proxy/Dockerfile
+++ b/sources/sdk/rust/example/proxy/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
-# rust:1.81-bullseye
+FROM rust:1.84-bullseye as builder
 RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && apt-get clean
 
 WORKDIR /usr/src

--- a/sources/sdk/rust/example/reactivator/Dockerfile
+++ b/sources/sdk/rust/example/reactivator/Dockerfile
@@ -6,8 +6,7 @@ COPY . .
 WORKDIR /usr/src
 RUN cargo install --force --path .
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/reactivator /usr/local/bin/reactivator
 CMD ["reactivator"]

--- a/sources/sdk/rust/example/reactivator/Dockerfile
+++ b/sources/sdk/rust/example/reactivator/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
-# rust:1.81-bullseye
+FROM rust:1.84-bullseye as builder
 RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && apt-get clean
 
 WORKDIR /usr/src

--- a/sources/shared/change-dispatcher/Dockerfile
+++ b/sources/shared/change-dispatcher/Dockerfile
@@ -26,8 +26,7 @@ COPY ./sources/shared/change-dispatcher .
 RUN cargo install --force --path .
 
     
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/change-dispatcher /usr/local/bin/change-dispatcher
 # RUN apt-get update && apt install -y openssl

--- a/sources/shared/change-router/Dockerfile
+++ b/sources/shared/change-router/Dockerfile
@@ -26,7 +26,7 @@ COPY ./sources/shared/change-router .
 RUN cargo install --force --path .
 
 
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 # RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/change-router /usr/local/bin/change-router

--- a/sources/shared/change-router/Dockerfile
+++ b/sources/shared/change-router/Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
-# rust:1.81-bullseye
-
+FROM rust:1.84-bullseye as builder
 RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && apt-get clean
 
 WORKDIR /usr/src

--- a/sources/shared/query-api/Dockerfile
+++ b/sources/shared/query-api/Dockerfile
@@ -26,8 +26,7 @@ COPY ./sources/shared/query-api .
 RUN cargo install --force --path .
 
     
-FROM gcr.io/distroless/cc-debian11@sha256:55a5e011b2c4246b4c51e01fcc2b452d151e03df052e357465f0392fcd59fddf
-# gcr.io/distroless/cc-debian11
+FROM gcr.io/distroless/cc-debian11
 ENV RUST_BACKTRACE=1
 COPY --from=builder /usr/local/cargo/bin/query-api /usr/local/bin/query-api
 # RUN apt-get update && apt install -y openssl


### PR DESCRIPTION
# Description
This pull request updates our release workflow by moving away from QEMU emulation for multi-platform Docker image builds to using native GitHub runners for linux/amd64 and linux/arm64 architectures. The goal is to enhance build stability and performance while keeping the workflow’s functionality intact.

This change should reduce the build time from 2-3 hours down to < 15 minutes.

### Details
1. Switch to Native Runners
  - Previously, multi-platform builds relied on QEMU emulation. Now, we use:
    - ubuntu-latest runners for linux/amd64.
    - ubuntu-24.04-arm runners for linux/arm64.
  - This removes emulation overhead, leading to fewer build failures and faster execution.

2. Platform-Specific Image Tagging
  - Docker images are now built and tagged individually per architecture:
    - Example: <image>:<tag>-amd64 for linux/amd64.
    - Example: <image>:<tag>-arm64 for linux/arm64.
  - A new manifest creation step combines these into a single multi-platform image (`<image>:<tag>`)
  - Therefore, users should be able to pull images seamlessly without needing to specify the architecture.
 
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- [ ] This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- [ ] This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- [x] This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).
