### PR TITLE
Updated the name of the Storage Queue reaction in the release workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -295,7 +295,7 @@ jobs:
           { 
             label: 'StorageQueue',
             path: './reactions/azure/storagequeue-reaction', 
-            name: 'reaction-storagequeue'
+            name: 'reaction-storage-queue'
           },
           { 
             label: 'StoredProc',

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -67,7 +67,7 @@ env:
     {"label": "EventBridge", "path": "reactions/aws/eventbridge-reaction", "name": "reaction-eventbridge", "platforms": "linux/amd64,linux/arm64"},
     {"label": "Gremlin", "path": "reactions/gremlin/gremlin-reaction", "name": "reaction-gremlin", "platforms": "linux/amd64,linux/arm64"},
     {"label": "Result", "path": "reactions/platform/result-reaction", "name": "reaction-result", "platforms": "linux/amd64,linux/arm64"},
-    {"label": "StorageQueue", "path": "reactions/azure/storagequeue-reaction", "name": "reaction-storagequeue", "platforms": "linux/amd64,linux/arm64"},
+    {"label": "StorageQueue", "path": "reactions/azure/storagequeue-reaction", "name": "reaction-storage-queue", "platforms": "linux/amd64,linux/arm64"},
     {"label": "StoredProc", "path": "reactions/sql/storedproc-reaction", "name": "reaction-storedproc", "platforms": "linux/amd64,linux/arm64"}]'
 
 jobs:


### PR DESCRIPTION
# Description

In the draft release workflow, the name of the storage queue reaction was `reaction-storagequeue`, but it should be `reaction-storage-queue`. This is consistent with the name of the image in the reaction provider.
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
