### PR TITLE
Fixed spelling of 'Installing'.

### DIFF
--- a/cli/service/installer.go
+++ b/cli/service/installer.go
@@ -555,7 +555,7 @@ func (t *Installer) installDapr(output output.TaskOutput, daprRegistry string) e
 
 	err := helmConfig.Init(&flags, "dapr-system", "secret", func(format string, v ...any) {})
 	if err != nil {
-		output.FailTask("Dapr-Install", fmt.Sprintf("Error intalling Dapr: %v", err.Error()))
+		output.FailTask("Dapr-Install", fmt.Sprintf("Error installing Dapr: %v", err.Error()))
 		return err
 	}
 
@@ -573,7 +573,7 @@ func (t *Installer) installDapr(output output.TaskOutput, daprRegistry string) e
 
 	dir, err := os.MkdirTemp("", "drasi")
 	if err != nil {
-		output.FailTask("Dapr-Install", fmt.Sprintf("Error intalling Dapr: %v", err.Error()))
+		output.FailTask("Dapr-Install", fmt.Sprintf("Error installing Dapr: %v", err.Error()))
 		return err
 	}
 	defer os.RemoveAll(dir)
@@ -582,18 +582,18 @@ func (t *Installer) installDapr(output output.TaskOutput, daprRegistry string) e
 
 	_, err = pull.Run("dapr")
 	if err != nil {
-		output.FailTask("Dapr-Install", fmt.Sprintf("Error intalling Dapr: %v", err.Error()))
+		output.FailTask("Dapr-Install", fmt.Sprintf("Error installing Dapr: %v", err.Error()))
 		return err
 	}
 	file, err := os.ReadDir(dir)
 	if err != nil {
-		output.FailTask("Dapr-Install", fmt.Sprintf("Error intalling Dapr: %v", err.Error()))
+		output.FailTask("Dapr-Install", fmt.Sprintf("Error installing Dapr: %v", err.Error()))
 		return err
 	}
 	dirPath := filepath.Join(dir, file[0].Name())
 	helmChart, err := loader.Load(dirPath)
 	if err != nil {
-		output.FailTask("Dapr-Install", fmt.Sprintf("Error intalling Dapr: %v", err.Error()))
+		output.FailTask("Dapr-Install", fmt.Sprintf("Error installing Dapr: %v", err.Error()))
 		return err
 	}
 
@@ -612,7 +612,7 @@ func (t *Installer) installDapr(output output.TaskOutput, daprRegistry string) e
 	}
 	_, err = installClient.Run(helmChart, helmChart.Values)
 	if err != nil {
-		output.FailTask("Dapr-Install", fmt.Sprintf("Error intalling Dapr: %v", err.Error()))
+		output.FailTask("Dapr-Install", fmt.Sprintf("Error installing Dapr: %v", err.Error()))
 		return err
 	}
 	output.SucceedTask("Dapr-Install", "Dapr installed successfully")


### PR DESCRIPTION
# Description

#193 


This pull request addresses a series of typos in the `installDapr` function within the `cli/service/installer.go` file. The changes correct the spelling of the word "installing" in multiple error messages.

Typo corrections:

* Corrected the spelling of "installing" in error messages within the `installDapr` function. [[1]](diffhunk://#diff-487f2ce6f01bed7ac5900d5fa59d2ebb36d9ab0ec06c1575ac86e95094b9f157L558-R558) [[2]](diffhunk://#diff-487f2ce6f01bed7ac5900d5fa59d2ebb36d9ab0ec06c1575ac86e95094b9f157L576-R576) [[3]](diffhunk://#diff-487f2ce6f01bed7ac5900d5fa59d2ebb36d9ab0ec06c1575ac86e95094b9f157L585-R596) [[4]](diffhunk://#diff-487f2ce6f01bed7ac5900d5fa59d2ebb36d9ab0ec06c1575ac86e95094b9f157L615-R615)
