### PR TITLE
Add k3d-load target to all Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ kind-load:
 	$(MAKE) -C sources $(MAKECMDGOALS)
 	$(MAKE) -C reactions $(MAKECMDGOALS)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	$(MAKE) -C control-planes $(MAKECMDGOALS)
+	$(MAKE) -C query-container $(MAKECMDGOALS)
+	$(MAKE) -C sources $(MAKECMDGOALS)
+	$(MAKE) -C reactions $(MAKECMDGOALS)
+
 test:
 	$(MAKE) -C control-planes $(MAKECMDGOALS)
 	$(MAKE) -C query-container $(MAKECMDGOALS)

--- a/control-planes/Makefile
+++ b/control-planes/Makefile
@@ -18,6 +18,11 @@ kind-load:
 	$(MAKE) -C mgmt_api $(MAKECMDGOALS)
 	$(MAKE) -C kubernetes_provider $(MAKECMDGOALS)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	$(MAKE) -C mgmt_api $(MAKECMDGOALS)
+	$(MAKE) -C kubernetes_provider $(MAKECMDGOALS)
+
 test:
 	$(MAKE) -C mgmt_api $(MAKECMDGOALS)
 	$(MAKE) -C kubernetes_provider $(MAKECMDGOALS)

--- a/control-planes/kubernetes_provider/Makefile
+++ b/control-planes/kubernetes_provider/Makefile
@@ -12,10 +12,13 @@ docker-build:
 
 docker-build-debug:
 	docker buildx build .. -f ./Dockerfile.debug -t $(IMAGE_PREFIX)/kubernetes-provider:$(DOCKER_TAG_VERSION) $(DOCKERX_OPTS)
-	
 
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/kubernetes-provider:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
+
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/kubernetes-provider:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
 
 test:
 	cargo test

--- a/control-planes/mgmt_api/Makefile
+++ b/control-planes/mgmt_api/Makefile
@@ -12,9 +12,13 @@ docker-build:
 
 docker-build-debug:
 	docker buildx build ../../ -f ./Dockerfile.debug -t $(IMAGE_PREFIX)/api:$(DOCKER_TAG_VERSION) $(DOCKERX_OPTS)
-	
+
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/api:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
+
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/api:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
 
 test:
 	cargo test

--- a/query-container/Makefile
+++ b/query-container/Makefile
@@ -21,6 +21,12 @@ kind-load:
 	$(MAKE) -C query-host $(MAKECMDGOALS)
 	$(MAKE) -C view-svc $(MAKECMDGOALS)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	$(MAKE) -C publish-api $(MAKECMDGOALS)
+	$(MAKE) -C query-host $(MAKECMDGOALS)
+	$(MAKE) -C view-svc $(MAKECMDGOALS)
+
 test:
 	$(MAKE) -C publish-api $(MAKECMDGOALS)
 	$(MAKE) -C query-host $(MAKECMDGOALS)

--- a/query-container/publish-api/Makefile
+++ b/query-container/publish-api/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/query-container-publish-api:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/query-container-publish-api:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	cargo test
 

--- a/query-container/query-host/Makefile
+++ b/query-container/query-host/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/query-container-query-host:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/query-container-query-host:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	cargo test
 

--- a/query-container/view-svc/Makefile
+++ b/query-container/view-svc/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/query-container-view-svc:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/query-container-view-svc:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	cargo test
 

--- a/reactions/Makefile
+++ b/reactions/Makefile
@@ -39,6 +39,18 @@ kind-load:
 	$(MAKE) -C platform/result-reaction $(MAKECMDGOALS)
 	$(MAKE) -C power-platform/dataverse/dataverse-reaction $(MAKECMDGOALS)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	$(MAKE) -C platform/debug-reaction $(MAKECMDGOALS)
+	$(MAKE) -C signalr/signalr-reaction $(MAKECMDGOALS)
+	$(MAKE) -C azure/eventgrid-reaction $(MAKECMDGOALS)
+	$(MAKE) -C azure/storagequeue-reaction $(MAKECMDGOALS)
+	$(MAKE) -C sql/storedproc-reaction $(MAKECMDGOALS)
+	$(MAKE) -C gremlin/gremlin-reaction $(MAKECMDGOALS)
+	$(MAKE) -C debezium/debezium-reaction $(MAKECMDGOALS)
+	$(MAKE) -C platform/result-reaction $(MAKECMDGOALS)
+	$(MAKE) -C power-platform/dataverse/dataverse-reaction $(MAKECMDGOALS)
+
 test:
 	$(MAKE) -C platform/debug-reaction $(MAKECMDGOALS)
 	$(MAKE) -C signalr/signalr-reaction $(MAKECMDGOALS)

--- a/reactions/aws/eventbridge-reaction/Makefile
+++ b/reactions/aws/eventbridge-reaction/Makefile
@@ -13,6 +13,10 @@ docker-build:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-eventbridge:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-eventbridge:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/reactions/azure/eventgrid-reaction/Makefile
+++ b/reactions/azure/eventgrid-reaction/Makefile
@@ -12,9 +12,13 @@ docker-build:
 
 docker-build-debug:
 	docker buildx build . -f Dockerfile.debug -t $(IMAGE_PREFIX)/reaction-eventgrid:$(DOCKER_TAG_VERSION) $(DOCKERX_OPTS)
-	
+
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-eventgrid:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
+
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-eventgrid:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
 
 test:
 	@echo "No tests to run yet"

--- a/reactions/azure/storagequeue-reaction/Makefile
+++ b/reactions/azure/storagequeue-reaction/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-storage-queue:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-storage-queue:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/reactions/debezium/debezium-reaction/Makefile
+++ b/reactions/debezium/debezium-reaction/Makefile
@@ -17,6 +17,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-debezium:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-debezium:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/reactions/gremlin/gremlin-reaction/Makefile
+++ b/reactions/gremlin/gremlin-reaction/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-gremlin:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-gremlin:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/reactions/platform/debug-reaction/Makefile
+++ b/reactions/platform/debug-reaction/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-debug:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-debug:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/reactions/platform/result-reaction/Makefile
+++ b/reactions/platform/result-reaction/Makefile
@@ -13,9 +13,12 @@ docker-build:
 docker-build-debug:
 	docker buildx build . -f Dockerfile.debug -t $(IMAGE_PREFIX)/reaction-result:$(DOCKER_TAG_VERSION) $(DOCKERX_OPTS)
 
-
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-result:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
+
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-result:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
 
 test:
 	@echo "No tests to run yet"

--- a/reactions/power-platform/dataverse/dataverse-reaction/Makefile
+++ b/reactions/power-platform/dataverse/dataverse-reaction/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-dataverse:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-dataverse:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/reactions/signalr/signalr-reaction/Makefile
+++ b/reactions/signalr/signalr-reaction/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-signalr:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-signalr:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	dotnet test
 

--- a/reactions/sql/storedproc-reaction/Makefile
+++ b/reactions/sql/storedproc-reaction/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/reaction-storedproc:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/reaction-storedproc:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -51,6 +51,22 @@ kind-load:
 	$(MAKE) -C kubernetes/kubernetes-reactivator $(MAKECMDGOALS)
 	$(MAKE) -C kubernetes/kubernetes-proxy $(MAKECMDGOALS)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	$(MAKE) -C cosmosdb/cosmosdb-ffcf-reactivator $(MAKECMDGOALS)
+	$(MAKE) -C cosmosdb/gremlin-proxy $(MAKECMDGOALS)
+	$(MAKE) -C relational/debezium-reactivator $(MAKECMDGOALS)
+	$(MAKE) -C relational/sql-proxy $(MAKECMDGOALS)
+	$(MAKE) -C shared/change-dispatcher $(MAKECMDGOALS)
+	$(MAKE) -C shared/change-router $(MAKECMDGOALS)
+	$(MAKE) -C shared/query-api $(MAKECMDGOALS)
+	$(MAKE) -C eventhub/eventhub-reactivator $(MAKECMDGOALS)
+	$(MAKE) -C eventhub/eventhub-proxy $(MAKECMDGOALS)
+	$(MAKE) -C dataverse/dataverse-reactivator $(MAKECMDGOALS)
+	$(MAKE) -C dataverse/dataverse-proxy $(MAKECMDGOALS)
+	$(MAKE) -C kubernetes/kubernetes-reactivator $(MAKECMDGOALS)
+	$(MAKE) -C kubernetes/kubernetes-proxy $(MAKECMDGOALS)
+
 test:
 	$(MAKE) -C cosmosdb/cosmosdb-ffcf-reactivator $(MAKECMDGOALS)
 	$(MAKE) -C cosmosdb/gremlin-proxy $(MAKECMDGOALS)

--- a/sources/cosmosdb/cosmosdb-ffcf-reactivator/Makefile
+++ b/sources/cosmosdb/cosmosdb-ffcf-reactivator/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-cosmosdb-reactivator:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-cosmosdb-reactivator:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/cosmosdb/gremlin-proxy/Makefile
+++ b/sources/cosmosdb/gremlin-proxy/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-gremlin-proxy:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-gremlin-proxy:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/dataverse/dataverse-proxy/Makefile
+++ b/sources/dataverse/dataverse-proxy/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-dataverse-proxy:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-dataverse-proxy:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/dataverse/dataverse-reactivator/Makefile
+++ b/sources/dataverse/dataverse-reactivator/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-dataverse-reactivator:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-dataverse-reactivator:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/eventhub/eventhub-proxy/Makefile
+++ b/sources/eventhub/eventhub-proxy/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-eventhub-proxy:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-eventhub-proxy:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/eventhub/eventhub-reactivator/Makefile
+++ b/sources/eventhub/eventhub-reactivator/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-eventhub-reactivator:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-eventhub-reactivator:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/kubernetes/kubernetes-proxy/Makefile
+++ b/sources/kubernetes/kubernetes-proxy/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-kubernetes-proxy:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-kubernetes-proxy:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/kubernetes/kubernetes-reactivator/Makefile
+++ b/sources/kubernetes/kubernetes-reactivator/Makefile
@@ -13,9 +13,12 @@ docker-build:
 docker-build-debug:
 	docker buildx build . -f Dockerfile.debug -t $(IMAGE_PREFIX)/source-kubernetes-reactivator:$(DOCKER_TAG_VERSION) $(DOCKERX_OPTS)
 
-
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-kubernetes-reactivator:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
+
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-kubernetes-reactivator:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
 
 test:
 	@echo "No tests to run yet"

--- a/sources/relational/debezium-reactivator/Makefile
+++ b/sources/relational/debezium-reactivator/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-debezium-reactivator:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-debezium-reactivator:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/relational/sql-proxy/Makefile
+++ b/sources/relational/sql-proxy/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-sql-proxy:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-sql-proxy:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/sdk/dotnet/examples/proxy/Makefile
+++ b/sources/sdk/dotnet/examples/proxy/Makefile
@@ -8,3 +8,7 @@ docker-build:
 
 kind-load:
 	kind load docker-image my-proxy --name $(CLUSTER_NAME)
+
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import my-proxy -c $(CLUSTER_NAME)

--- a/sources/sdk/dotnet/examples/reactivator/Makefile
+++ b/sources/sdk/dotnet/examples/reactivator/Makefile
@@ -8,3 +8,7 @@ docker-build:
 
 kind-load:
 	kind load docker-image my-reactivator --name $(CLUSTER_NAME)
+
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import my-reactivator --name $(CLUSTER_NAME)

--- a/sources/sdk/java/example/proxy/Makefile
+++ b/sources/sdk/java/example/proxy/Makefile
@@ -9,3 +9,6 @@ docker-build:
 kind-load:
 	kind load docker-image my-proxy --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import my-proxy --name $(CLUSTER_NAME)

--- a/sources/sdk/java/example/reactivator/Makefile
+++ b/sources/sdk/java/example/reactivator/Makefile
@@ -9,3 +9,6 @@ docker-build:
 kind-load:
 	kind load docker-image my-reactivator --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import my-reactivator --name $(CLUSTER_NAME)

--- a/sources/sdk/rust/example/proxy/Makefile
+++ b/sources/sdk/rust/example/proxy/Makefile
@@ -9,3 +9,6 @@ docker-build:
 kind-load:
 	kind load docker-image my-proxy --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import my-proxy --name $(CLUSTER_NAME)

--- a/sources/sdk/rust/example/reactivator/Makefile
+++ b/sources/sdk/rust/example/reactivator/Makefile
@@ -9,3 +9,6 @@ docker-build:
 kind-load:
 	kind load docker-image my-reactivator --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import my-reactivator --name $(CLUSTER_NAME)

--- a/sources/shared/change-dispatcher/Makefile
+++ b/sources/shared/change-dispatcher/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-change-dispatcher:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-change-dispatcher:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/shared/change-router/Makefile
+++ b/sources/shared/change-router/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-change-router:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-change-router:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 

--- a/sources/shared/query-api/Makefile
+++ b/sources/shared/query-api/Makefile
@@ -16,6 +16,10 @@ docker-build-debug:
 kind-load:
 	kind load docker-image $(IMAGE_PREFIX)/source-query-api:$(DOCKER_TAG_VERSION) --name $(CLUSTER_NAME)
 
+k3d-load: CLUSTER_NAME=k3s-default
+k3d-load:
+	k3d image import $(IMAGE_PREFIX)/source-query-api:$(DOCKER_TAG_VERSION) -c $(CLUSTER_NAME)
+
 test:
 	@echo "No tests to run yet"
 


### PR DESCRIPTION
# Description

Support loading Drasi images into local k3d cluster.

Use `k3d image import` command to import docker images into k3d cluster.

## Type of change
- [ ] This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- [ ] This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- [x] This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).