### PR TITLE
Configure Dependabot for Grouped Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,207 @@
+# Copyright 2024 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This configuration manages Dependabot updates for the repository.
+#
+# 1. Reduce the number of individual Dependabot PRs.
+# 2. Group updates by type (patch, minor) for commonly used technologies.
+# 3. Major version updates will create separate PRs to ensure visibility.
+# 4. Schedule updates across different days to distribute review load.
+# 5. Provide a catch-all for less frequently used or future technologies.
+
+version: 2
+updates:
+  # Rust (cargo) - Updates on Monday
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      rust-patch:
+        patterns:
+          - "*" # All Rust dependencies for patch updates
+        update-types:
+          - "patch"
+      rust-minor:
+        patterns:
+          - "*" # All Rust dependencies for minor updates
+        update-types:
+          - "minor"
+    open-pull-requests-limit: 5
+
+  # .NET (nuget) - Updates on Tuesday
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    groups:
+      dotnet-patch:
+        patterns:
+          - "*" # All .NET dependencies for patch updates
+        update-types:
+          - "patch"
+      dotnet-minor:
+        patterns:
+          - "*" # All .NET dependencies for minor updates
+        update-types:
+          - "minor"
+    open-pull-requests-limit: 5
+
+  # Go (gomod) - Updates on Wednesday
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      go-patch:
+        patterns:
+          - "*" # All Go dependencies for patch updates
+        update-types:
+          - "patch"
+      go-minor:
+        patterns:
+          - "*" # All Go dependencies for minor updates
+        update-types:
+          - "minor"
+    open-pull-requests-limit: 5
+
+  # Java (maven) - Updates on Wednesday
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      java-patch:
+        patterns:
+          - "*" # All Maven dependencies for patch updates
+        update-types:
+          - "patch"
+      java-minor:
+        patterns:
+          - "*" # All Maven dependencies for minor updates
+        update-types:
+          - "minor"
+    open-pull-requests-limit: 5
+
+  # Python (pip) - Updates on Wednesday
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      python-patch:
+        patterns:
+          - "*" # All Python dependencies for patch updates
+        update-types:
+          - "patch"
+      python-minor:
+        patterns:
+          - "*" # All Python dependencies for minor updates
+        update-types:
+          - "minor"
+    open-pull-requests-limit: 5
+  
+  # Docker - Updates on Thursday
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+    groups:
+      docker-patch:
+        patterns:
+          - "*" # All Docker image dependencies for patch updates
+        update-types:
+          - "patch"
+      docker-minor:
+        patterns:
+          - "*" # All Docker image dependencies for minor updates
+        update-types:
+          - "minor"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions - Updates on Thursday
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+    groups:
+      actions-patch:
+        patterns:
+          - "*" 
+        update-types:
+          - "patch"
+      actions-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+    open-pull-requests-limit: 5
+
+  # Node.js (npm) - Updates on Friday
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    groups:
+      nodejs-patch:
+        patterns:
+          - "*" # All npm dependencies for patch updates
+        update-types:
+          - "patch"
+      nodejs-minor:
+        patterns:
+          - "*" # All npm dependencies for minor updates
+        update-types:
+          - "minor"
+    open-pull-requests-limit: 5
+
+  # Bundler (Ruby) - Updates on Sunday
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      bundler-all-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 2
+
+  # Gradle (Java/Kotlin) - Updates on Sunday
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      gradle-all-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
# Description

This PR introduces a `dependabot.yml` configuration to streamline dependency updates across our repo. The goal is to reduce the volume of individual Dependabot PRs by grouping updates.

**Key Changes:**

*   **Enabled Dependabot Grouped Updates:**
    *   For primary ecosystems (Rust, .NET, Go, Java/Maven, Python/pip, Docker, GitHub Actions, Node.js/npm), patch and minor updates are grouped separately.
    *   Major version updates will still create separate PRs for visibility.
    *   These updates are scheduled on different days of the week (Monday-Friday) to distribute the review load.
    *   `open-pull-requests-limit` is set to `5` for each of these ecosystems.
*   **Future Ecosystem Coverage:**
    *   Configurations have been added for other ecosystems supported by Dependabot which we haven't used yet (Gradle, Bundler).
    *   For these ecosystems, all update types (major, minor, patch) are consolidated into a single group per ecosystem.
    *   These are scheduled for Sunday.
    *   `open-pull-requests-limit` is set to `2` for each of these "catch-all" Sunday groups.

**Expected Outcome:**

*   Reduction in the number of open Dependabot PRs.
*   More manageable review cycles for dependency updates.

**Important Considerations:**
*   **New Technologies:** If new package ecosystems are introduced to the repository, this `dependabot.yml` file will need to be updated to include them.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- [ ] This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- [ ] This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- [x] This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).
