### PR TITLE
Fix enum parsing bug in Post-PubSub-Reaction

### DIFF
--- a/e2e-tests/06-post-dapr-pubsub-scenario/reactions.yaml
+++ b/e2e-tests/06-post-dapr-pubsub-scenario/reactions.yaml
@@ -8,13 +8,13 @@ spec:
       {
         "pubsubName": "drasitest-pubsub",
         "topicName": "e2e-topic-packed",
-        "outputFormat": "Packed",
+        "format": "Packed",
         "skipControlSignals": false
       }
     product-updates-unpacked: >
       {
         "pubsubName": "drasitest-pubsub",
         "topicName": "e2e-topic-unpacked",
-        "outputFormat": "Unpacked",
+        "format": "Unpacked",
         "skipControlSignals": true
       }

--- a/reactions/dapr/post-pubsub/Drasi.Reactions.PostDaprPubSub/QueryConfig.cs
+++ b/reactions/dapr/post-pubsub/Drasi.Reactions.PostDaprPubSub/QueryConfig.cs
@@ -57,6 +57,7 @@ public class QueryConfig : IValidatableObject
     /// Specifies how events should be formatted when published.
     /// </summary>
     [JsonPropertyName("format")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public OutputFormat Format { get; set; } = OutputFormat.Unpacked;
     
     /// <summary>


### PR DESCRIPTION
# Description

- Fixes a enum parsing bug in the Post-Dapr-PubSub-Reaction.
- Also fixes the E2E test, which was not catching the bug.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi .