### PR TITLE
VsCode extension bug - init error when drasi config does not exists

### DIFF
--- a/dev-tools/vscode/drasi/src/sdk/config.ts
+++ b/dev-tools/vscode/drasi/src/sdk/config.ts
@@ -47,12 +47,14 @@ export class ConfigurationRegistry implements Disposable {
 
     constructor() {
         this.basePath = this.getHomeDir() + "/.drasi";
-        this.eventEmitter = new EventEmitter();
-        this.watcher = fs.watch(this.basePath + "/" + currentFile, (eventType, filename) => {
-            if (eventType === "change" && filename === currentFile) {
-                this.eventEmitter.emit("currentRegistrationChanged");
-            }
-        });
+        this.eventEmitter = new EventEmitter();        
+        if (fs.existsSync(this.basePath + "/" + currentFile)) {
+            this.watcher = fs.watch(this.basePath + "/" + currentFile, (eventType, filename) => {
+                if (eventType === "change" && filename === currentFile) {
+                    this.eventEmitter.emit("currentRegistrationChanged");
+                }
+            });
+        }
     }
     
     dispose() {


### PR DESCRIPTION
# Description

The Vs Code extension fails to initialize if the `.drasi` config file does not exist in the user profile. This becomes apparent with the codespace / dev container tutorials, where the extension is installed and started before drasi is installed. The issue was that it creates a file watch on a path that does not exist at startup.