### PR TITLE
Disable Auto Merge for Renovate PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,8 +2,8 @@ name: Automerge Renovate PRs
 
 on:
   schedule:
-    # Runs at 12:00 PM Pacific Time on Wednesdays.
-    - cron: '0 19 * * 3'
+    # Disable AutoRun for now: Runs at 12:00 PM Pacific Time on Wednesdays.
+    # - cron: '0 19 * * 3'
   workflow_dispatch: # Allows manual triggering
 
 permissions:


### PR DESCRIPTION
# Description

Disable cron schedule of `automerge` workflow.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).
