### PR TITLE
Add GQL (Graph Query Language) Support into Drasi Platform

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "query-container/query-host/drasi-core"]
 	path = query-container/query-host/drasi-core
 	url = https://github.com/drasi-project/drasi-core.git
-	branch = feature-gql

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "query-container/query-host/drasi-core"]
 	path = query-container/query-host/drasi-core
-	url = https://github.com/drasi-project/drasi-core.git
+	url = https://github.com/project-drasi/drasi-core.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "query-container/query-host/drasi-core"]
 	path = query-container/query-host/drasi-core
-	url = https://github.com/project-drasi/drasi-core.git
+	url = https://github.com/drasi-project/drasi-core.git
+	branch = feature-gql

--- a/control-planes/mgmt_api/src/api/v1/mappings/query.rs
+++ b/control-planes/mgmt_api/src/api/v1/mappings/query.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use crate::domain::models::{
-    QueryJoin, QueryJoinKey, QuerySourceLabel, QuerySources, QuerySpec, QueryStatus,
+    QueryJoin, QueryJoinKey, QueryLanguage, QuerySourceLabel, QuerySources, QuerySpec, QueryStatus,
     QuerySubscription, RetentionPolicy, SourceMiddlewareConfig, ViewSpec,
 };
 
 use super::{
-    QueryJoinDto, QueryJoinKeyDto, QuerySourceLabelDto, QuerySourcesDto, QuerySpecDto,
+    QueryJoinDto, QueryJoinKeyDto, QueryLanguageDto, QuerySourceLabelDto, QuerySourcesDto, QuerySpecDto,
     QueryStatusDto, QuerySubscriptionDto, RetentionPolicyDto, SourceMiddlewareConfigDto,
     ViewSpecDto,
 };
@@ -40,6 +40,7 @@ impl From<QuerySpecDto> for QuerySpec {
             container: spec.container,
             mode: spec.mode,
             query: spec.query,
+            query_language: spec.query_language.map(|lang| lang.into()),
             sources: spec.sources.into(),
             storage_profile: spec.storage_profile,
             view: spec.view.unwrap_or_default().into(),
@@ -54,6 +55,7 @@ impl From<QuerySpec> for QuerySpecDto {
             container: spec.container,
             mode: spec.mode,
             query: spec.query,
+            query_language: spec.query_language.map(|lang| lang.into()),
             sources: spec.sources.into(),
             storage_profile: spec.storage_profile,
             view: Some(spec.view.into()),
@@ -238,6 +240,24 @@ impl From<ViewSpec> for ViewSpecDto {
         ViewSpecDto {
             enabled: spec.enabled,
             retention_policy: spec.retention_policy.into(),
+        }
+    }
+}
+
+impl From<QueryLanguageDto> for QueryLanguage {
+    fn from(lang: QueryLanguageDto) -> Self {
+        match lang {
+            QueryLanguageDto::Cypher => QueryLanguage::Cypher,
+            QueryLanguageDto::GQL => QueryLanguage::GQL,
+        }
+    }
+}
+
+impl From<QueryLanguage> for QueryLanguageDto {
+    fn from(lang: QueryLanguage) -> Self {
+        match lang {
+            QueryLanguage::Cypher => QueryLanguageDto::Cypher,
+            QueryLanguage::GQL => QueryLanguageDto::GQL,
         }
     }
 }

--- a/control-planes/mgmt_api/src/api/v1/mappings/query.rs
+++ b/control-planes/mgmt_api/src/api/v1/mappings/query.rs
@@ -18,9 +18,9 @@ use crate::domain::models::{
 };
 
 use super::{
-    QueryJoinDto, QueryJoinKeyDto, QueryLanguageDto, QuerySourceLabelDto, QuerySourcesDto, QuerySpecDto,
-    QueryStatusDto, QuerySubscriptionDto, RetentionPolicyDto, SourceMiddlewareConfigDto,
-    ViewSpecDto,
+    QueryJoinDto, QueryJoinKeyDto, QueryLanguageDto, QuerySourceLabelDto, QuerySourcesDto,
+    QuerySpecDto, QueryStatusDto, QuerySubscriptionDto, RetentionPolicyDto,
+    SourceMiddlewareConfigDto, ViewSpecDto,
 };
 
 impl From<QueryStatus> for QueryStatusDto {

--- a/control-planes/mgmt_api/src/api/v1/models/query.rs
+++ b/control-planes/mgmt_api/src/api/v1/models/query.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum QueryLanguageDto {
     #[serde(rename = "Cypher")]
     Cypher,

--- a/control-planes/mgmt_api/src/api/v1/models/query.rs
+++ b/control-planes/mgmt_api/src/api/v1/models/query.rs
@@ -15,6 +15,14 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum QueryLanguageDto {
+    #[serde(rename = "Cypher")]
+    Cypher,
+    #[serde(rename = "GQL")]
+    GQL,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QuerySourceLabelDto {
@@ -51,6 +59,7 @@ pub struct QuerySpecDto {
     pub container: String,
     pub mode: String,
     pub query: String,
+    pub query_language: Option<QueryLanguageDto>,
     pub sources: QuerySourcesDto,
     pub storage_profile: Option<String>,
     pub view: Option<ViewSpecDto>,

--- a/control-planes/mgmt_api/src/domain/mappings.rs
+++ b/control-planes/mgmt_api/src/domain/mappings.rs
@@ -311,11 +311,21 @@ impl From<SourceMiddlewareConfig> for resource_provider_api::models::SourceMiddl
     }
 }
 
+impl From<QueryLanguage> for resource_provider_api::models::QueryLanguage {
+    fn from(lang: QueryLanguage) -> resource_provider_api::models::QueryLanguage {
+        match lang {
+            QueryLanguage::Cypher => resource_provider_api::models::QueryLanguage::Cypher,
+            QueryLanguage::GQL => resource_provider_api::models::QueryLanguage::GQL,
+        }
+    }
+}
+
 impl From<QuerySpec> for resource_provider_api::models::QuerySpec {
     fn from(query_spec: QuerySpec) -> resource_provider_api::models::QuerySpec {
         resource_provider_api::models::QuerySpec {
             mode: query_spec.mode,
             query: query_spec.query,
+            query_language: query_spec.query_language.map(|lang| lang.into()),
             sources: query_spec.sources.into(),
             storage_profile: query_spec.storage_profile,
             view: query_spec.view.into(),

--- a/control-planes/mgmt_api/src/domain/models.rs
+++ b/control-planes/mgmt_api/src/domain/models.rs
@@ -168,12 +168,21 @@ pub struct QueryJoin {
     pub keys: Vec<QueryJoinKey>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum QueryLanguage {
+    #[serde(rename = "Cypher")]
+    Cypher,
+    #[serde(rename = "GQL")]
+    GQL,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QuerySpec {
     pub container: String,
     pub mode: String,
     pub query: String,
+    pub query_language: Option<QueryLanguage>,
     pub sources: QuerySources,
     pub storage_profile: Option<String>,
     pub view: ViewSpec,

--- a/control-planes/mgmt_api/src/domain/models.rs
+++ b/control-planes/mgmt_api/src/domain/models.rs
@@ -169,6 +169,7 @@ pub struct QueryJoin {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum QueryLanguage {
     #[serde(rename = "Cypher")]
     Cypher,

--- a/control-planes/resource_provider_api/src/models.rs
+++ b/control-planes/resource_provider_api/src/models.rs
@@ -22,6 +22,14 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 use void::Void;
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum QueryLanguage {
+    #[serde(rename = "Cypher")]
+    Cypher,
+    #[serde(rename = "GQL")]
+    GQL,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Resource<TSpec, TStatus> {
     pub id: String,
@@ -284,6 +292,7 @@ pub struct SourceMiddlewareConfig {
 pub struct QuerySpec {
     pub mode: String,
     pub query: String,
+    pub query_language: Option<QueryLanguage>,
     pub sources: QuerySources,
     pub storage_profile: Option<String>,
     pub view: ViewSpec,

--- a/control-planes/resource_provider_api/src/models.rs
+++ b/control-planes/resource_provider_api/src/models.rs
@@ -200,7 +200,7 @@ pub enum ServiceIdentity {
     MicrosoftEntraApplication {
         #[serde(rename = "tenantId")]
         tenant_id: ConfigValue,
-        
+
         #[serde(rename = "clientId")]
         client_id: ConfigValue,
 
@@ -227,7 +227,7 @@ pub enum ServiceIdentity {
         secret_access_key: ConfigValue,
         #[serde(rename = "region")]
         aws_region: ConfigValue,
-    }
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/control-planes/resource_provider_api/src/models.rs
+++ b/control-planes/resource_provider_api/src/models.rs
@@ -23,6 +23,7 @@ use serde_json::{Map, Value};
 use void::Void;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum QueryLanguage {
     #[serde(rename = "Cypher")]
     Cypher,

--- a/query-container/Cargo.lock
+++ b/query-container/Cargo.lock
@@ -871,6 +871,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "drasi-functions-cypher"
+version = "0.2.0"
+dependencies = [
+ "drasi-core",
+]
+
+[[package]]
+name = "drasi-functions-gql"
+version = "0.2.0"
+dependencies = [
+ "drasi-core",
+ "tokio",
+]
+
+[[package]]
 name = "drasi-index-garnet"
 version = "0.1.0"
 dependencies = [
@@ -947,6 +962,16 @@ dependencies = [
 
 [[package]]
 name = "drasi-query-cypher"
+version = "0.1.0"
+dependencies = [
+ "drasi-query-ast",
+ "peg",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "drasi-query-gql"
 version = "0.1.0"
 dependencies = [
  "drasi-query-ast",
@@ -2561,11 +2586,14 @@ dependencies = [
  "dapr",
  "dapr-macros",
  "drasi-core",
+ "drasi-functions-cypher",
+ "drasi-functions-gql",
  "drasi-index-garnet",
  "drasi-index-rocksdb",
  "drasi-middleware",
  "drasi-query-ast",
  "drasi-query-cypher",
+ "drasi-query-gql",
  "either",
  "env_logger 0.11.5",
  "futures",
@@ -3301,6 +3329,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "drasi-core",
+ "drasi-functions-cypher",
  "drasi-middleware",
  "drasi-query-ast",
  "drasi-query-cypher",

--- a/query-container/query-host/Cargo.toml
+++ b/query-container/query-host/Cargo.toml
@@ -8,7 +8,10 @@ edition = "2021"
 [dependencies]
 drasi-core = { path = "./drasi-core/core" }
 drasi-query-cypher = { path = "./drasi-core/query-cypher" }
+drasi-query-gql = { path = "./drasi-core/query-gql" }
 drasi-query-ast = { path = "./drasi-core/query-ast" }
+drasi-functions-cypher = { path = "./drasi-core/functions-cypher" }
+drasi-functions-gql = { path = "./drasi-core/functions-gql" }
 drasi-middleware = { path = "./drasi-core/middleware" }
 drasi-index-garnet = { path = "./drasi-core/index-garnet" }
 drasi-index-rocksdb = { path = "./drasi-core/index-rocksdb" }

--- a/query-container/query-host/src/api.rs
+++ b/query-container/query-host/src/api.rs
@@ -25,6 +25,14 @@ use drasi_core::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum QueryLanguage {
+    #[serde(rename = "Cypher")]
+    Cypher,
+    #[serde(rename = "GQL")]
+    GQL,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct QueryRequest {
     pub id: String,
@@ -81,6 +89,7 @@ pub struct SourceMiddlewareConfig {
 pub struct QuerySpec {
     pub mode: String,
     pub query: String,
+    pub query_language: Option<QueryLanguage>,
     pub sources: QuerySources,
     pub storage_profile: Option<String>,
     pub view: ViewSpec,

--- a/query-container/query-host/src/api.rs
+++ b/query-container/query-host/src/api.rs
@@ -26,6 +26,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum QueryLanguage {
     #[serde(rename = "Cypher")]
     Cypher,

--- a/query-container/query-host/src/query_worker.rs
+++ b/query-container/query-host/src/query_worker.rs
@@ -50,7 +50,7 @@ use tracing::{dispatcher, info_span, instrument, Dispatch, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{
-    api::{self, ChangeEvent, ControlSignal, ResultEvent, QueryLanguage},
+    api::{self, ChangeEvent, ControlSignal, QueryLanguage, ResultEvent},
     change_stream::{
         self, redis_change_stream::RedisChangeStream, Message, SequentialChangeStream,
     },
@@ -109,13 +109,15 @@ impl QueryWorker {
                     Some(QueryLanguage::GQL) => {
                         let function_registry =
                             Arc::new(FunctionRegistry::new()).with_gql_function_set();
-                        let parser = Arc::new(GQLParser::new(function_registry.clone())) as Arc<dyn QueryParser>;
+                        let parser = Arc::new(GQLParser::new(function_registry.clone()))
+                            as Arc<dyn QueryParser>;
                         (parser, function_registry)
                     }
                     Some(QueryLanguage::Cypher) | None => {
                         let function_registry =
                             Arc::new(FunctionRegistry::new()).with_cypher_function_set();
-                        let parser = Arc::new(CypherParser::new(function_registry.clone())) as Arc<dyn QueryParser>;
+                        let parser = Arc::new(CypherParser::new(function_registry.clone()))
+                            as Arc<dyn QueryParser>;
                         (parser, function_registry)
                     }
                 };


### PR DESCRIPTION
## Summary

This PR adds support for specifying query language in continuous query YAML configuration. Users can now select between Cypher and GQL languages using the optional `queryLanguage` property.

## Usage

Users can now specify query language in their continuous query YAML:

```yaml
apiVersion: v1
kind: ContinuousQuery
spec:
  mode: query
  queryLanguage: Cypher
  query: "MATCH (n) RETURN n"
  # ... other configuration
```

Or for GQL:

```yaml
apiVersion: v1
kind: ContinuousQuery
spec:
  mode: query
  queryLanguage: GQL
  query: "MATCH (n) RETURN n"
  # ... other configuration
```

Existing queries without `queryLanguage` property continue to default to Cypher

This PR also updates drasi-core to track the most recent commit on core. 