### PR TITLE
Bug-fix for SQL Server Managed Identity

### DIFF
--- a/cli/installers/resources/default-source-providers.yaml
+++ b/cli/installers/resources/default-source-providers.yaml
@@ -167,8 +167,6 @@ spec:
       - database
       - host
       - port
-      - password
-      - user
       - tables
 ---
 apiVersion: v1

--- a/sources/relational/sql-proxy/src/main/java/io/drasi/ResultStream.java
+++ b/sources/relational/sql-proxy/src/main/java/io/drasi/ResultStream.java
@@ -79,8 +79,14 @@ public class ResultStream implements BootstrapStream {
                 return DriverManager.getConnection(jdbcConnectionString, propsMySql);
             case "SQLServer":
                 var propsSQL = new Properties();
-                propsSQL.setProperty("user", SourceProxy.GetConfigValue("user"));
-                propsSQL.setProperty("password", SourceProxy.GetConfigValue("password"));
+                String sqlUser = SourceProxy.GetConfigValue("user");
+                String sqlPassword = SourceProxy.GetConfigValue("password");
+                if (sqlUser != null) {
+                    propsSQL.setProperty("user", sqlUser);
+                }
+                if (sqlPassword != null) {
+                    propsSQL.setProperty("password", sqlPassword);
+                }
                 propsSQL.setProperty("encrypt", SourceProxy.GetConfigValue("encrypt"));
                 propsSQL.setProperty("trustServerCertificate", SourceProxy.GetConfigValue("trustServerCertificate", "false"));
                 propsSQL.setProperty("authentication", SourceProxy.GetConfigValue("authentication", "NotSpecified"));


### PR DESCRIPTION
This pull request fixes an issue on how SQL Server connection credentials are handled in both the configuration and code, ensuring that user and password properties are only set if they are present. This helps prevent issues when those credentials are omitted, for example, when using Managed Identity.

**Configuration changes:**

* Removed `user` and `password` from the required specification fields in `default-source-providers.yaml` for SQLServer, making them optional for source providers.

**Connection logic improvements:**

* Updated the SQL Server connection logic in `ResultStream.java` to only set the `user` and `password` properties if their values are not null, providing better support for optional credentials.