### PR TITLE
Fix alternate schema bug in sql proxy

### DIFF
--- a/sources/relational/sql-proxy/src/main/java/io/drasi/TableRegistry.java
+++ b/sources/relational/sql-proxy/src/main/java/io/drasi/TableRegistry.java
@@ -1,0 +1,43 @@
+package io.drasi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.drasi.source.sdk.SourceProxy;
+
+public class TableRegistry {
+    private final Map<String, String> tableSchemaMap;
+
+    public TableRegistry() {
+        this.tableSchemaMap = new HashMap<>();
+        parseTablesConfig();
+    }
+
+    private void parseTablesConfig() {
+        String tablesEnv = SourceProxy.GetConfigValue("tables");
+        if (tablesEnv == null || tablesEnv.trim().isEmpty()) {
+            return;
+        }
+
+        String[] tables = tablesEnv.split(",");
+        for (String table : tables) {
+            String trimmedTable = table.trim();
+            if (trimmedTable.contains(".")) {
+                String[] parts = trimmedTable.split("\\.", 2);
+                String schema = parts[0].trim();
+                String tableName = parts[1].trim();
+                tableSchemaMap.put(tableName, schema);
+            } else {
+                tableSchemaMap.put(trimmedTable, null);
+            }
+        }
+    }
+
+    public boolean tableExists(String tableName) {
+        return tableSchemaMap.containsKey(tableName);
+    }
+
+    public String getSchemaName(String tableName) {
+        return tableSchemaMap.get(tableName);
+    }
+}


### PR DESCRIPTION
This pull request refactors the way tables and schemas are handled in the SQL proxy by introducing a new `TableRegistry` class and updating the table cursor logic to support schema-qualified table names. The changes improve robustness when dealing with tables from multiple schemas and ensure that only registered tables are processed, and fixes a bug where tables in the non-default schema could not be bootstrapped.

**Schema and Table Registry Improvements:**

* Added a new `TableRegistry` class to manage table-to-schema mappings, parsing the `tables` config and providing lookup methods for table existence and schema name. (`sources/relational/sql-proxy/src/main/java/io/drasi/TableRegistry.java`)
* Updated `ResultStream` to instantiate and use `TableRegistry`, checking if each requested table exists and retrieving its schema before creating `TableCursor` instances. Unregistered tables are logged and skipped. (`sources/relational/sql-proxy/src/main/java/io/drasi/ResultStream.java`) [[1]](diffhunk://#diff-3bf6025a2a9d7303bbc3bb129f2e41a5c7e69067021c3fd64eee65cbc3fabc8bR17-R23) [[2]](diffhunk://#diff-3bf6025a2a9d7303bbc3bb129f2e41a5c7e69067021c3fd64eee65cbc3fabc8bL30-R37)

**Table Cursor and Query Handling:**

* Refactored `TableCursor` to accept both `schemaName` and `tableName` in its constructor, and to use these values when building SQL queries and reading table mappings. (`sources/relational/sql-proxy/src/main/java/io/drasi/TableCursor.java`)
* Updated SQL query construction in `TableCursor` to use fully qualified table names (including schema when present), ensuring correct querying in multi-schema environments. (`sources/relational/sql-proxy/src/main/java/io/drasi/TableCursor.java`)
* Simplified and clarified the logic for reading table mappings and primary keys, passing schema and table names directly and improving error messages for missing primary keys. (`sources/relational/sql-proxy/src/main/java/io/drasi/TableCursor.java`)