### PR TITLE
Add AGENTS.md for CLI and Control-Planes

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1,0 +1,97 @@
+# AGENTS.md: Drasi CLI
+
+This document provides a high-level overview of the Drasi Command Line Interface (CLI) project for coding agents. The CLI is a Go application built with the Cobra library, responsible for installing and managing Drasi environments and resources.
+
+The `README.md` file contains additional context intended for human developers. For a detailed command reference, use the CLI's built-in `help` command (e.g., `drasi help apply`).
+
+## Core Workflow
+
+A typical command execution follows this flow:
+1.  The user runs a command defined in the **`cmd/`** directory.
+2.  The command uses the **`sdk/`** to get a `PlatformClient` for the target environment.
+3.  The `PlatformClient` establishes a connection (e.g., a Kubernetes port-forward) and provides an `ApiClient`.
+4.  The command uses the `ApiClient` to make HTTP calls to the Drasi Management API.
+5.  Throughout the process, the **`output/`** package is used to render status and results to the user's terminal.
+
+## Component Diagram
+
+This diagram shows the structural dependencies between the major packages in the CLI.
+
+```mermaid
+graph TD
+    subgraph "Entry Point"
+        main("main.go")
+    end
+
+    subgraph "Command Layer"
+        Cmd("cmd/")
+    end
+
+    subgraph "Service & Abstraction Layers"
+        SDK("sdk/")
+        Installers("installers/")
+    end
+    
+    subgraph "Utility & Data Packages"
+        Output("output/")
+        API("api/")
+        Config("config/")
+        Registry("sdk/registry/")
+    end
+
+    main --> Cmd
+    
+    Cmd --> SDK
+    Cmd --> Installers
+    Cmd --> Output
+    Cmd --> Config
+
+    Installers --> SDK
+    Installers --> API
+
+    SDK --> API
+    SDK --> Registry
+```
+
+## Project Structure
+
+The CLI's functionality is organized into the following key directories. Each contains a local `AGENTS.md` file for more detailed information.
+
+-   **`api/`**: Defines the core Go structs (`Manifest`, `Resource`) that represent Drasi resources in YAML files and in API communications. This is the foundational data model for the CLI.
+-   **`cmd/`**: Contains the implementation for every user-facing command (e.g., `drasi apply`, `drasi init`). This is the entry point for all CLI functionality and orchestrates calls to the `sdk` and `installers`.
+-   **`config/`**: Defines and initializes global, build-time variables like `Version` and `Registry`.
+-   **`installers/`**: Holds the logic for installing and uninstalling Drasi environments. It abstracts platform specifics (Kubernetes vs. Docker) and contains the embedded YAML manifests for deployment in its `resources/` subdirectory.
+-   **`output/`**: Manages all terminal output. It provides a rich, interactive UI for terminals and falls back to plain-text logging for non-interactive environments.
+-   **`sdk/`**: The core abstraction layer. It provides a `PlatformClient` to handle environment-specific operations (like port-forwarding in Kubernetes) and an `ApiClient` to communicate with the Drasi Management API.
+
+## Key Abstractions
+
+-   **`sdk.PlatformClient`**: An interface that decouples the CLI commands from the underlying platform (e.g., Kubernetes). Implementations handle tasks like creating API clients, managing tunnels, and interacting with the platform's secret store. See `sdk/platform_client.go`.
+-   **`installers.Installer`**: An interface for the multi-step process of deploying a Drasi environment. The `KubernetesInstaller` is the primary implementation. See `installers/installer.go`.
+-   **`output.TaskOutput`**: An interface for rendering progress to the user, with implementations for rich terminal UIs and simple log output. See `output/interface.go`.
+
+## Build and Test
+
+The project is built using Go and a `Makefile`.
+
+-   **Build for all platforms**:
+    ```bash
+    make
+    ```
+-   **Build for the current platform**:
+    ```bash
+    make build
+    ```
+-   **Install a local build**:
+    ```bash
+    # macOS / Linux
+    sudo make install
+
+    # Windows (in an elevated terminal)
+    make install
+    ```
+-   **Formatting and Linting**:
+    ```bash
+    make fmt
+    make vet
+    ```

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/cli/api/AGENTS.md
+++ b/cli/api/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md: `cli/api` Directory
+
+This directory contains the core Go data structures that represent Drasi resources and manifests. These types are used by the CLI to parse resource definition files and to serialize/deserialize data when communicating with the Drasi Management API.
+
+## Files
+
+### `manifest.go`
+
+-   **Purpose**: Defines the structure for a Drasi resource manifest, which is how resources are defined in YAML files. It provides a utility function to read and parse one or more YAML documents from a byte slice.
+-   **Key Components**:
+    -   `Manifest` (struct): Represents a single resource definition from a YAML file. It includes fields like `Kind`, `ApiVersion`, `Name`, and `Spec`. This is the primary structure used when parsing files for `drasi apply` or `drasi delete`.
+    -   `ReadManifests([]byte)` (function): A parser that takes raw byte data (from a YAML file) and decodes it into a slice of `Manifest` structs, correctly handling multi-document YAML files.
+
+### `resource.go`
+
+-   **Purpose**: Defines the generic structure for a Drasi resource as it is represented by the Drasi Management API.
+-   **Key Components**:
+    -   `Resource` (struct): A generic representation of any Drasi resource (Source, Reaction, Query, etc.). It contains the `Id`, the configuration (`Spec`), and the current operational state (`Status`) of the resource. This struct is used for handling responses from the management API, such as for the `drasi describe` command.

--- a/cli/api/CLAUDE.md
+++ b/cli/api/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/cli/cmd/AGENTS.md
+++ b/cli/cmd/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md: `cli/cmd` Directory
+
+This directory contains the implementation for each command available in the Drasi CLI (e.g., `apply`, `list`, `init`). It uses the `Cobra` library to structure the commands, arguments, and flags. Each file typically defines a single top-level command and its associated logic.
+
+The general pattern for each command is:
+1.  Define the `cobra.Command` struct with its `Use`, `Short`, and `Long` descriptions.
+2.  Implement the `RunE` function, which contains the core logic for the command.
+3.  Inside `RunE`, parse flags, load the current environment configuration (`registry.LoadCurrentRegistration`), create a platform client (`sdk.NewPlatformClient`), and execute the desired action.
+
+## Files
+
+### `root.go`
+
+-   **Purpose**: This is the entry point for the CLI. It creates the root `drasi` command and attaches all other commands (from the other files in this directory) to it.
+-   **Key Components**:
+    -   `MakeRootCommand()`: Initializes the main `drasi` command and registers all subcommands. It also defines persistent flags like `--namespace` that are available globally.
+
+### Resource Management Commands
+
+-   **`apply.go`**: Implements the `drasi apply` command. It loads resource manifests from files (`-f` flag) and sends them to the Drasi Management API to be created or updated.
+-   **`delete.go`**: Implements the `drasi delete` command. It can delete resources specified by `[kind] [name]` arguments or from manifest files (`-f` flag).
+-   **`describe.go`**: Implements the `drasi describe` command. It fetches and displays the detailed configuration (`spec`) and current `status` of a single, specified resource.
+-   **`list.go`**: Implements the `drasi list` command. It retrieves a list of resources of a given kind and displays their status in a table format.
+-   **`wait.go`**: Implements the `drasi wait` command. It blocks until specified resources become fully operational or a timeout is reached. This is useful for scripting.
+
+### Installation & Environment Commands
+
+-   **`init.go`**: Implements the `drasi init` command. This is a complex command responsible for installing Drasi into a Kubernetes cluster or a local Docker container. It handles various flags for customization (`--local`, `--version`, `--registry`, `--manifest`, etc.).
+-   **`uninstall.go`**: Implements the `drasi uninstall` command. It removes a Drasi installation by deleting its Kubernetes namespace and can optionally remove Dapr as well.
+-   **`env.go`**: Implements the `drasi env` command and its subcommands (`all`, `current`, `delete`, `kube`, `use`). It manages saved connection configurations for different Drasi environments.
+-   **`namespace.go`**: Implements the `drasi namespace` command and its subcommands (`get`, `set`, `list`). It manages the default Kubernetes namespace that the CLI targets.
+
+### Utility & Debugging Commands
+
+-   **`watch.go`**: Implements the `drasi watch` command. It connects to a query's real-time view service and displays a continuously updating table of its result set.
+-   **`tunnel.go`**: Implements the `drasi tunnel` command. It creates a local port forward to a service running inside the Kubernetes cluster, enabling local debugging.
+-   **`secret.go`**: Implements the `drasi secret` command and its subcommands (`set`, `delete`). It provides a way to manage Kubernetes secrets for storing sensitive data.
+-   **`version.go`**: Implements the `drasi version` command. It's a simple command that prints the compiled-in version of the CLI.
+-   **`utils.go`**: Contains helper functions used by other commands in this directory, notably `loadManifests`, which is responsible for reading resource definitions from files, URLs, or standard input.

--- a/cli/cmd/CLAUDE.md
+++ b/cli/cmd/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/cli/config/AGENTS.md
+++ b/cli/config/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md: `cli/config` Directory
+
+This directory contains global configuration for the Drasi CLI application.
+
+## Files
+
+### `config.go`
+
+-   **Purpose**: Defines and initializes global, package-level variables for the CLI. These variables are typically set at build time to inject versioning and other important information into the binary.
+-   **Key Components**:
+    -   `Version` (string): Stores the version of the Drasi CLI. It defaults to `"latest"` if not set during the build process. This is the version displayed by the `drasi version` command and used by default in `drasi init`.
+    -   `Registry` (string): Stores the default container registry path to pull Drasi images from. It defaults to `"ghcr.io"` if not set during the build. This is used by the `drasi init` command.

--- a/cli/config/CLAUDE.md
+++ b/cli/config/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/cli/installers/AGENTS.md
+++ b/cli/installers/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md: `cli/installers` Directory
+
+This directory contains the logic for installing, uninstalling, and managing Drasi environments on different platforms (primarily Kubernetes). It abstracts the platform-specific details of deployment behind a set of interfaces. The `drasi init` and `drasi uninstall` commands delegate their core work to the components in this directory.
+
+## Core Interfaces
+
+### `installer.go`
+
+-   **Purpose**: Defines the main `Installer` interface. This provides a generic contract for installing Drasi, regardless of the target platform.
+-   **Key Components**:
+    -   `Installer` (interface): The core interface with the `Install(...)` method.
+    -   `MakeInstaller(...)` (factory function): A factory function that takes a `registry.Registration` (which defines the target environment) and returns the appropriate concrete `Installer` implementation (e.g., `KubernetesInstaller`).
+
+### `uninstaller.go`
+
+-   **Purpose**: Defines the `Uninstaller` interface for removing Drasi from an environment.
+-   **Key Components**:
+    -   `Uninstaller` (interface): The core interface with the `Uninstall(...)` method.
+    -   `MakeUninstaller(...)` (factory function): A factory that returns the correct `Uninstaller` implementation based on the target environment.
+
+## Kubernetes Implementation
+
+### `kubernetes_installer.go`
+
+-   **Purpose**: Provides the concrete implementation of the `Installer` interface for Kubernetes. This is a complex file that handles the multi-step process of deploying Drasi.
+-   **Key Responsibilities**:
+    -   Checking for and installing Dapr using a Helm chart.
+    -   Creating the target Kubernetes namespace.
+    -   Applying Kubernetes manifests for core infrastructure (Redis, Mongo), observability tools (Tempo, Prometheus, Grafana), and the Drasi control plane services.
+    -   Templating manifest files with correct image tags and registry paths.
+    -   Waiting for deployments and statefulsets to become ready.
+    -   Using the Drasi client (`sdk`) to apply the default Drasi resources (QueryContainer, SourceProviders, etc.) after the control plane is up.
+    -   Contains embedded YAML files for all necessary resources in the `resources` directory.
+
+### `kubernetes_uninstaller.go`
+
+-   **Purpose**: Implements the `Uninstaller` interface for Kubernetes.
+-   **Key Responsibilities**:
+    -   Deleting the entire Kubernetes namespace where Drasi is installed.
+    -   Waiting for the namespace to be fully terminated.
+    -   Optionally deleting the `dapr-system` namespace if requested.
+
+### `kubernetes_manifest_installer.go`
+
+-   **Purpose**: Implements the `Installer` interface for the `--manifest` flag of the `drasi init` command. Instead of deploying directly to a cluster, it generates the necessary Kubernetes and Drasi YAML files.
+-   **Key Responsibilities**:
+    -   Generating YAML strings for all required resources (Namespace, ConfigMap, Control Plane, etc.).
+    -   Writing the generated Kubernetes resources to `kubernetes-resources.yaml`.
+    -   Writing the generated Drasi resources (QueryContainer, Providers) to `drasi-resources.yaml`.
+
+## Docker Implementation
+
+### `dockerized_deployer.go`
+
+-   **Purpose**: Handles the logic for creating and managing a self-contained Drasi environment running inside a local Docker container. This is used by the `drasi init --docker` command.
+-   **Key Responsibilities**:
+    -   Building a Docker container with a K3d (Kubernetes in Docker) cluster inside.
+    -   Loading local Drasi container images into the K3d cluster.
+    -   Running the `drasi init` process within the container to set up Drasi.
+    -   Deleting the Docker container when the environment is removed.
+
+## Supporting Files
+
+-   **`install-drasi-cli.sh` / `install-drasi-cli.ps1`**: Helper scripts for users to easily download and install the Drasi CLI binary.
+-   **`resources/`**: An embedded directory containing all the default YAML manifests required for a Drasi installation, defining everything from Kubernetes infrastructure (Redis, Mongo) to the default Drasi providers. For a detailed breakdown of these manifests, see the `AGENTS.md` file within this directory.

--- a/cli/installers/CLAUDE.md
+++ b/cli/installers/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/cli/installers/resources/AGENTS.md
+++ b/cli/installers/resources/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md: `cli/installers/resources` Directory
+
+This directory contains the raw YAML manifest files that are embedded into the CLI binary and used by the `KubernetesInstaller` to deploy a Drasi environment. These files define all the necessary Kubernetes and Drasi resources for a standard installation.
+
+The installer templates these files, replacing placeholders like `%TAG%` and `%ACR%` with the correct values at installation time.
+
+## Kubernetes Resource Manifests
+
+### `infra.yaml`
+
+-   **Purpose**: Defines the core stateful infrastructure and Dapr components required by Drasi.
+-   **Key Components**:
+    -   `StatefulSet` for `drasi-redis`: Deploys a Redis instance for pub/sub messaging and caching.
+    -   `StatefulSet` for `drasi-mongo`: Deploys a MongoDB instance, primarily used for storing query results and actor state.
+    -   `PriorityClass` (`drasi-infrastructure`): Ensures that these core infrastructure pods are scheduled with high priority.
+    -   Dapr `Component` (`drasi-state`): Configures the MongoDB instance as the state store for Dapr actors.
+    -   Dapr `Component` (`drasi-pubsub`): Configures the Redis instance as the message bus for Dapr pub/sub.
+    -   Dapr `Configuration` (`dapr-config`): Provides default Dapr configuration, including enabling tracing.
+
+### `control-plane.yaml`
+
+-   **Purpose**: Defines the core Drasi control plane services.
+-   **Key Components**:
+    -   `Deployment` for `drasi-resource-provider`: The service responsible for managing and reconciling Drasi resources (Sources, Reactions, etc.) within the Kubernetes cluster.
+    -   `Deployment` for `drasi-api`: The main management API that the Drasi CLI interacts with to manage the environment.
+    -   `Service` for `drasi-api`: Exposes the management API internally within the cluster.
+
+### `service-account.yaml`
+
+-   **Purpose**: Defines the Kubernetes RBAC (Role-Based Access Control) permissions required for the Drasi control plane to function.
+-   **Key Components**:
+    -   `ServiceAccount` (`drasi-resource-provider`): The identity used by the resource provider pod.
+    -   `Role` (`drasi-resource-provider-role`): Grants necessary permissions to create, delete, list, and update Kubernetes resources like Deployments, Services, ConfigMaps, and Dapr Components.
+    -   `RoleBinding`: Binds the `Role` to the `ServiceAccount`.
+
+### `observability/`
+
+-   **Purpose**: This subdirectory contains manifests for deploying optional observability tools.
+-   **Files**:
+    -   `tracing.yaml`: Deploys Grafana Tempo for distributed tracing.
+    -   `metrics.yaml`: Deploys Prometheus for metrics collection.
+    -   `full-observability.yaml`: Deploys both Tempo and Prometheus.
+    -   `otel-collector.yaml`: Deploys the OpenTelemetry Collector to receive and forward telemetry data.
+
+## Drasi Resource Manifests
+
+These files define the default Drasi resources that are created during a fresh installation.
+
+### `default-container.yaml`
+
+-   **Purpose**: Defines the default `QueryContainer` resource.
+-   **Details**: This sets up the initial environment where continuous queries will run. It configures Redis as the default store and MongoDB for storing query results.
+
+### `default-source-providers.yaml`
+
+-   **Purpose**: Defines the built-in `SourceProvider` resources.
+-   **Details**: This multi-document YAML file registers all the out-of-the-box source types that Drasi supports, such as `PostgreSQL`, `SQLServer`, `CosmosGremlin`, `Kubernetes`, etc. Each provider definition includes the necessary configuration schema and specifies the container images for its proxy and reactivator services.
+
+### `default-reaction-providers.yaml`
+
+-   **Purpose**: Defines the built-in `ReactionProvider` resources.
+-   **Details**: This multi-document YAML file registers all the out-of-the-box reaction types, such as `EventGrid`, `SignalR`, `Gremlin`, `StoredProc`, `Http`, etc. It defines their configuration schemas and the container images for their services.

--- a/cli/installers/resources/CLAUDE.md
+++ b/cli/installers/resources/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/cli/output/AGENTS.md
+++ b/cli/output/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md: `cli/output` Directory
+
+This directory is responsible for handling all user-facing output from the Drasi CLI, particularly for long-running or multi-step operations like `drasi init`. It provides an abstraction that can produce rich, interactive terminal UIs when run in a TTY environment, and fall back to simple, plain-text logging when the output is being piped or redirected.
+
+## Core Abstraction
+
+### `interface.go`
+
+-   **Purpose**: Defines the core `TaskOutput` interface that all CLI commands use to report progress and status to the user.
+-   **Key Components**:
+    -   `TaskOutput` (interface): A contract for displaying hierarchical task progress. It includes methods like `AddTask`, `SucceedTask`, `FailTask`, and `GetChildren` to create nested tasks.
+    -   `NewTaskOutput()` (factory function): This is the main entry point. It intelligently detects if the CLI is running in an interactive terminal.
+        -   If **yes**, it returns the rich `taskOutputBubbleTea` implementation.
+        -   If **no** (e.g., in a CI/CD pipeline), it returns the simple `taskOutputNoTerm` implementation.
+
+## Implementations
+
+### `task_output.go`
+
+-   **Purpose**: Provides a rich, interactive terminal UI for displaying task progress. This is the implementation used in a standard terminal session.
+-   **Key Components**:
+    -   `taskOutputBubbleTea` (struct): The main model that implements the `TaskOutput` interface.
+    -   **Technology**: It is built using the `Bubble Tea` TUI (Text-based User Interface) framework.
+    -   **Features**:
+        -   Displays spinners for tasks that are in progress.
+        -   Uses color-coded symbols (✓, ✗, ℹ) to indicate task success, failure, or information.
+        -   Supports a hierarchical/nested view for sub-tasks.
+        -   Handles asynchronous updates via a message queue (`chan`).
+
+### `task_output_noterm.go`
+
+-   **Purpose**: Provides a simple, plain-text logger for non-interactive environments.
+-   **Key Components**:
+    -   `taskOutputNoTerm` (struct): A struct that implements the `TaskOutput` interface.
+    -   **Functionality**: It simply prints status updates to standard output as single lines prefixed with `[SUCCESS]`, `[FAILED]`, `[INFO]`, etc. This ensures that logs are clean and easily parsable by other tools.
+
+## Subdirectories
+
+### `query_results/`
+
+-   **Purpose**: Contains the specific UI components for the `drasi watch` command, which displays a real-time, continuously updating table of a query's result set. This is also built using the `Bubble Tea` framework.

--- a/cli/output/CLAUDE.md
+++ b/cli/output/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/cli/sdk/AGENTS.md
+++ b/cli/sdk/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md: `cli/sdk` Directory
+
+This directory contains the Software Development Kit (SDK) for the Drasi CLI. Its primary role is to provide a clean abstraction layer between the CLI commands (`cmd/` directory) and the underlying Drasi platform. It handles the details of communicating with the Drasi Management API and managing different platform environments (like Kubernetes or Docker).
+
+## Core Abstractions
+
+### `platform_client.go`
+
+-   **Purpose**: Defines the `PlatformClient` interface, which abstracts away the specifics of the hosting environment. This allows the CLI commands to work seamlessly whether Drasi is running in Kubernetes or a local Docker container.
+-   **Key Components**:
+    -   `PlatformClient` (interface): A contract for platform-specific operations. Key methods include:
+        -   `CreateDrasiClient()`: Returns an `ApiClient` for communicating with the Drasi Management API.
+        -   `CreateTunnel(...)`: Establishes a port-forwarding tunnel to a resource.
+        -   `SetSecret(...)` / `DeleteSecret(...)`: Manages secrets in the platform's native secret store.
+    -   `KubernetesPlatformClient` (struct): The concrete implementation for Kubernetes. It uses the `k8s.io/client-go` library to interact with the Kubernetes API, manage port-forwarding, and handle secrets.
+    -   `NewPlatformClient(...)` (factory function): A factory that inspects the current environment configuration (from the `registry`) and returns the appropriate `PlatformClient` implementation.
+
+### `api_client.go`
+
+-   **Purpose**: Provides a high-level client for interacting with the Drasi Management API. It encapsulates the logic for making HTTP requests to the various API endpoints.
+-   **Key Components**:
+    -   `ApiClient` (struct): The client that communicates with the Drasi API, typically over a port-forward tunnel established by the `PlatformClient`.
+    -   **Methods**: It provides methods that map directly to the CLI commands and API capabilities:
+        -   `Apply(...)`: Creates or updates resources (`drasi apply`).
+        -   `Delete(...)`: Deletes resources (`drasi delete`).
+        -   `GetResource(...)`: Fetches details for a single resource (`drasi describe`).
+        -   `ListResources(...)`: Lists all resources of a given kind (`drasi list`).
+        -   `ReadyWait(...)`: Blocks until a resource is ready (`drasi wait`).
+        -   `Watch(...)`: Streams real-time results from a query (`drasi watch`).
+    -   `kindRoutes` (map): A mapping from the user-friendly resource kind names (e.g., "query") to the actual API route paths (e.g., "continuousQueries").
+
+## Subdirectories
+
+### `registry/`
+
+-   **Purpose**: This subdirectory is responsible for managing the configuration of different Drasi environments that the CLI can connect to. It handles saving, loading, and switching between connection profiles (e.g., different Kubernetes contexts or local Docker instances). For more details, see the `AGENTS.md` file within this directory.

--- a/cli/sdk/CLAUDE.md
+++ b/cli/sdk/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/AGENTS.md
+++ b/control-planes/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md: `control-planes` Directory
+
+This directory contains the source code for the Drasi platform's backend, known as the Control Plane.
+
+## Architectural Context
+
+-   **Role**: Drasi Platform Backend / Control Plane.
+-   **Purpose**: Manages the complete lifecycle of all Drasi resources (Sources, Queries, Reactions).
+-   **Architecture**: A pluggable microservices system built on the Kubernetes Controller pattern.
+-   **Communication**: Dapr is used for all inter-service communication (e.g., pub/sub).
+
+## Component Breakdown
+
+The control plane is composed of three primary Rust projects:
+
+-   **`mgmt_api/`**: The central orchestrator. It exposes the public API, receives commands from the `drasi` CLI, manages the desired state of resources in MongoDB, and delegates implementation tasks to providers.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`kubernetes_provider/`**: The implementer for the Kubernetes platform. It subscribes to commands from the `mgmt_api` and translates abstract Drasi resources into concrete Kubernetes objects (`Deployment`, `Service`, etc.).
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`resource_provider_api/`**: A shared library crate that defines the communication contract (data models) used between the `mgmt_api` and any provider. It is not a running service.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+## Control Flow Diagram
+
+This diagram illustrates the typical workflow for creating a resource.
+
+```mermaid
+graph TD
+    CLI["drasi CLI"] -->|1. HTTP Request| MgmtApi["mgmt_api"];
+    MgmtApi <-->|2. Persist Desired State| DB["(MongoDB)"];
+    MgmtApi -- "3. Publish Command<br/>(uses resource_provider_api models)" --> Bus["(Dapr Pub/Sub)"];
+    Bus -->|4. Deliver Command| Provider["kubernetes_provider"];
+    Provider -->|5. Manage Objects| K8sApi["(Kubernetes API)"];
+```
+
+## Development
+
+The top-level `Makefile` provides scripts to build the Docker images for the services.
+
+-   **Build `mgmt_api` image**:
+    ```bash
+    make build-api
+    ```
+-   **Build `kubernetes_provider` image**:
+    ```bash
+    make build-provider
+    ```

--- a/control-planes/CLAUDE.md
+++ b/control-planes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/kubernetes_provider/AGENTS.md
+++ b/control-planes/kubernetes_provider/AGENTS.md
@@ -1,0 +1,49 @@
+# Drasi Kubernetes Provider
+
+This directory contains the Drasi Kubernetes Provider, a Rust-based controller that translates abstract Drasi resources into concrete Kubernetes objects.
+
+## Architectural Context
+
+-   **Type**: Kubernetes Controller / Dapr Actor Service.
+-   **Role**: The "hands" of the Drasi control plane. It receives commands from the `mgmt_api` and is responsible for the platform-specific implementation of Drasi resources within a Kubernetes cluster.
+-   **Key Technologies**:
+    -   Rust
+    -   `kube-rs` (Kubernetes client)
+    -   `dapr-rs` (Dapr client and actor runtime)
+-   **Primary Input**: `ResourceRequest<TSpec>` objects from the `resource_provider_api`.
+-   **Primary Output**: Kubernetes objects (`Deployment`, `Service`, `ConfigMap`, etc.).
+
+## Internal Architecture Summary
+
+The provider's source code is located in the `src/` directory and follows a clean, layered architecture.
+
+-   **`src/actors/`**: The command-receiving layer. Dapr actors (`SourceActor`, etc.) receive `configure` and `deprovision` commands.
+-   **`src/spec_builder/`**: The translation layer. It converts the abstract Drasi resource spec into a detailed `KubernetesSpec` data structure.
+-   **`src/controller/`**: The core reconciliation layer. It takes a `KubernetesSpec` and uses `kube-rs` to apply it to the cluster, ensuring the actual state matches the desired state.
+-   **For a complete breakdown, see the `AGENTS.md` file in the `src/` directory.**
+
+## Deployment
+
+-   **Method**: Deployed automatically by the Drasi CLI (`drasi init` command) using an embedded manifest.
+-   **Development Manifest**: The `deploy.yaml` file in this directory is for standalone development and testing only.
+
+## Development
+
+This project is a standard Rust application built into a Docker image.
+
+-   **Build Docker Image**:
+    ```bash
+    make docker-build
+    ```
+-   **Run Tests**:
+    ```bash
+    make test
+    ```
+-   **Check Formatting & Lint**:
+    ```bash
+    make lint-check
+    ```
+-   **Load Image to local Kind cluster**:
+    ```bash
+    make kind-load
+    ```

--- a/control-planes/kubernetes_provider/CLAUDE.md
+++ b/control-planes/kubernetes_provider/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/kubernetes_provider/GEMINI.md
+++ b/control-planes/kubernetes_provider/GEMINI.md
@@ -1,0 +1,57 @@
+# Project Overview
+
+This project is a Kubernetes provider for the Drasi platform, implemented as a Rust-based controller. It leverages the `kube-rs` library for Kubernetes API interaction and the Dapr actor model for managing custom resources.
+
+The provider is responsible for reconciling the state of various Drasi resources within a Kubernetes cluster. It manages the lifecycle of Deployments, Services, ConfigMaps, ServiceAccounts, and other Kubernetes objects based on custom specifications.
+
+## Core Components
+
+-   **`main.rs`**: The application's entry point. It initializes the Dapr server, registers the resource actors, and sets up the Kubernetes client.
+-   **`controller/reconciler.rs`**: Contains the core reconciliation logic. It continuously monitors the state of managed resources and performs create, update, or delete operations to match the desired state defined in the `KubernetesSpec`.
+-   **`models.rs`**: Defines the primary data structures, including `KubernetesSpec`, which encapsulates the desired state for a managed resource, and `ResourceType` (Source, Reaction, QueryContainer).
+-   **`actors/*.rs`**: Implements the Dapr actor logic for different resource types (`SourceActor`, `ReactionActor`, `QueryContainerActor`). These actors receive configuration and lifecycle commands to manage their corresponding Kubernetes resources via the reconciler.
+-   **`spec_builder/*.rs`**: Contains logic for constructing the detailed `KubernetesSpec` from higher-level configuration.
+
+The system is designed to be deployed on Kubernetes, as indicated by the `deploy.yaml` manifest and various Dockerfiles.
+
+# Building and Running
+
+The `Makefile` provides several scripts for building, testing, and deploying the provider.
+
+-   **Build the Docker image:**
+    ```bash
+    make docker-build
+    ```
+
+-   **Run tests:**
+    ```bash
+    make test
+    ```
+
+-   **Check formatting and lint:**
+    ```bash
+    make lint-check
+    ```
+
+-   **Load the Docker image into a local Kind or K3d cluster:**
+    ```bash
+    # For Kind
+    make kind-load
+
+    # For K3d
+    make k3d-load
+    ```
+
+-   **Deploy to Kubernetes:**
+    The `deploy.yaml` file contains the necessary manifests for deploying the provider and its associated RBAC rules.
+    ```bash
+    kubectl apply -f deploy.yaml
+    ```
+
+# Development Conventions
+
+-   **Language:** The project is written in idiomatic Rust.
+-   **Formatting & Linting:** Code is formatted with `cargo fmt` and linted with `cargo clippy`. The CI checks in the `Makefile` enforce these standards.
+-   **Kubernetes Controller Pattern:** The reconciler follows the standard Kubernetes controller pattern. It uses a hash of the resource specification (`drasi/spechash` annotation) to efficiently check for changes and determine whether to update a resource.
+-   **Dapr Integration:** The application is tightly integrated with Dapr, using it for the actor model and as a sidecar in the Kubernetes deployment.
+-   **Configuration:** Runtime configuration is managed through environment variables and a `RuntimeConfig` struct, as seen in `models.rs`.

--- a/control-planes/kubernetes_provider/src/AGENTS.md
+++ b/control-planes/kubernetes_provider/src/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md: `control-planes/kubernetes_provider/src` Directory
+
+This directory contains the complete source code for the Drasi Kubernetes Provider. It is the top-level entry point for understanding the controller's construction and internal architecture.
+
+## Architectural Context
+
+-   **Role**: Application Crate Root.
+-   **Purpose**: To define the application's binary entry point (`main.rs`) and declare the top-level modules that make up the controller. This is where all the components are wired together.
+
+## Key Files
+
+-   **`main.rs`**:
+    -   **Purpose**: The main entry point for the `kubernetes_provider` binary.
+    -   **Key Responsibilities**:
+        -   **Initialization**: Connects to the Kubernetes cluster and the Dapr sidecar.
+        -   **Dapr Server Setup**: Initializes the Dapr HTTP server.
+        -   **Actor Registration**: Registers the concrete actor types (`SourceActor`, `ReactionActor`, `QueryContainerActor`) with the Dapr runtime. This involves providing factory functions that create new actor instances, injecting dependencies like the `RuntimeConfig` and the Kubernetes client configuration.
+        -   **Monitor**: Starts a background monitoring task.
+        -   **Server Start**: Starts the Dapr server to begin listening for actor invocations.
+
+-   **`models.rs`**:
+    -   **Purpose**: Defines the core internal data structures for the provider.
+    -   **Key Components**:
+        -   `KubernetesSpec` (struct): **This is the most important data structure in the provider.** It represents the complete desired state of all Kubernetes objects for a single Drasi resource service. It is created by the `spec_builder` and consumed by the `controller`.
+        -   `RuntimeConfig` (struct): A struct that holds runtime configuration, loaded from environment variables, such as the container image registry, tags, and Dapr settings.
+
+## Subdirectories
+
+The controller is organized into a clean, layered architecture.
+
+-   **`actors/`**:
+    -   **Purpose**: The command-receiving layer. Contains the Dapr actor implementations that receive `configure` and `deprovision` commands from the `mgmt_api`.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`spec_builder/`**:
+    -   **Purpose**: The translation layer. Takes an abstract Drasi resource spec and builds the detailed, concrete `KubernetesSpec`.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`controller/`**:
+    -   **Purpose**: The core reconciliation layer. Takes a `KubernetesSpec` and applies it to the cluster, ensuring the actual state matches the desired state.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`monitor/`**:
+    -   **Purpose**: A background task that monitors the health and status of Drasi-managed pods and reports updates.

--- a/control-planes/kubernetes_provider/src/CLAUDE.md
+++ b/control-planes/kubernetes_provider/src/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/kubernetes_provider/src/actors/AGENTS.md
+++ b/control-planes/kubernetes_provider/src/actors/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md: `control-planes/kubernetes_provider/src/actors` Directory
+
+This directory contains the Dapr actor implementations. These actors are the primary entry point for commands sent from the `mgmt_api` to the `kubernetes_provider`.
+
+## Architectural Context
+
+-   **Role**: Command and Control Layer.
+-   **Purpose**: To receive `configure` and `deprovision` commands for a specific resource instance. Each resource (e.g., a Source with ID `my-db`) is represented by a unique Dapr actor instance. The actor is responsible for managing the state and lifecycle of that resource.
+-   **Technology**: Dapr Actors (via the `dapr-rs` crate).
+
+## File Structure
+
+-   **`mod.rs`**:
+    -   **Purpose**: Defines the generic `ResourceActor` struct, which contains the common logic for all resource actors.
+    -   **Key Components**:
+        -   `ResourceActor<TSpec, TStatus>` (struct): A generic actor implementation.
+        -   `on_activate()`: When an actor activates, it reads its saved `KubernetesSpec` from the Dapr state store and starts the `ResourceController` to reconcile its state.
+        -   `configure()`: This is the main method called by the `mgmt_api`. It receives a resource specification, uses the `spec_builder` to translate it into a `KubernetesSpec`, saves this spec to the Dapr state store, and triggers the `ResourceController` to reconcile.
+        -   `deprovision()`: Marks the resource's spec as "removed", saves it, and triggers the `ResourceController` to delete the associated Kubernetes objects.
+
+-   **`source_actor.rs`**:
+    -   **Purpose**: Defines the concrete `SourceActor`.
+    -   **Implementation**: Uses the `#[actor]` macro to create a concrete type alias for `ResourceActor<SourceSpec, SourceStatus>`. It injects the `SourceSpecBuilder` to handle the spec translation. It also provides a `get_status` method to report the current state of the source's Kubernetes objects.
+
+-   **`reaction_actor.rs`**:
+    -   **Purpose**: Defines the concrete `ReactionActor`.
+    -   **Implementation**: Similar to the `SourceActor`, it creates a type alias for `ResourceActor<ReactionSpec, ReactionStatus>` and injects the `ReactionSpecBuilder`.
+
+-   **`querycontainer_actor.rs`**:
+    -   **Purpose**: Defines the concrete `QueryContainerActor`.
+    -   **Implementation**: Similar to the other actors, it creates a type alias for `ResourceActor<QueryContainerSpec, QueryContainerStatus>` and injects the `QueryContainerSpecBuilder`.

--- a/control-planes/kubernetes_provider/src/actors/CLAUDE.md
+++ b/control-planes/kubernetes_provider/src/actors/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/kubernetes_provider/src/controller/AGENTS.md
+++ b/control-planes/kubernetes_provider/src/controller/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md: `control-planes/kubernetes_provider/src/controller` Directory
+
+This directory contains the core logic of the Kubernetes controller. It is responsible for the reconciliation loop that ensures the actual state of resources in the cluster matches the desired state defined by a `KubernetesSpec`.
+
+## Architectural Context
+
+-   **Role**: Kubernetes Controller / Reconciliation Loop.
+-   **Purpose**: To take a `KubernetesSpec` (built by the `spec_builder`) and use the `kube-rs` client to create, update, or delete the corresponding Kubernetes objects (`Deployment`, `Service`, `ConfigMap`, etc.). This is the "engine room" of the provider.
+
+## File Structure
+
+-   **`mod.rs`**:
+    -   **Purpose**: Provides a high-level `ResourceController` abstraction that manages the lifecycle of a reconciliation task.
+    -   **Key Components**:
+        -   `ResourceController` (struct): A handle to a running reconciliation task. It spawns a `tokio` task to run the reconciler and provides an MPSC channel (`commander`) to send commands (`Reconcile`, `Deprovision`) to it. This allows the Dapr actors to safely interact with the reconciler in a concurrent environment.
+
+-   **`reconciler.rs`**:
+    -   **Purpose**: This is the most critical file in the provider. It contains the `ResourceReconciler` struct, which implements the actual reconciliation logic.
+    -   **Key Components**:
+        -   `ResourceReconciler` (struct): Holds the `KubernetesSpec` (the desired state) and `kube-rs` API clients for various Kubernetes object types.
+        -   `reconcile()` (method): The main entry point for the reconciliation loop. It calls a series of `reconcile_*` methods (e.g., `reconcile_deployment`, `reconcile_config_maps`) for each object type.
+        -   **Reconciliation Logic**: Each `reconcile_*` method typically follows this pattern:
+            1.  Attempt to `get` the object from the Kubernetes API.
+            2.  If it **exists**, compare its `drasi/spechash` annotation with a newly calculated hash of the desired spec.
+            3.  If the hashes differ, `patch` or `replace` the existing object.
+            4.  If it **does not exist** (404 error), `create` the new object.
+        -   **Hashing**: A hash of the resource's specification is stored in the `drasi/spechash` annotation on the Kubernetes object. This is a key optimization that allows the reconciler to quickly and efficiently determine if an object is up-to-date without needing to perform a deep comparison of all its fields.

--- a/control-planes/kubernetes_provider/src/controller/CLAUDE.md
+++ b/control-planes/kubernetes_provider/src/controller/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/kubernetes_provider/src/spec_builder/AGENTS.md
+++ b/control-planes/kubernetes_provider/src/spec_builder/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md: `control-planes/kubernetes_provider/src/spec_builder` Directory
+
+This directory contains the logic for translating abstract Drasi resource specifications into concrete Kubernetes object specifications.
+
+## Architectural Context
+
+-   **Role**: Kubernetes Spec Translation Layer.
+-   **Purpose**: To take a high-level Drasi resource definition (e.g., a `SourceSpec` from the `resource_provider_api`) and build the corresponding detailed Kubernetes manifests (`Deployment`, `Service`, `ConfigMap`, etc.) required to run that resource in the cluster. This is the "translation engine" of the Kubernetes provider.
+
+## File Structure
+
+-   **`mod.rs`**:
+    -   **Purpose**: Defines the generic `SpecBuilder` trait and provides the central `build_deployment_spec` function.
+    -   **Key Components**:
+        -   `SpecBuilder<TSpec>` (trait): A generic contract for any struct that can build a `KubernetesSpec`.
+        -   `build_deployment_spec(...)`: A powerful, generic function that constructs a `k8s_openapi::api::apps::v1::DeploymentSpec`. It is responsible for populating the spec with the correct container image, environment variables, Dapr annotations, labels, ports, and volumes. This function is the core of all spec building.
+
+-   **`source.rs`**:
+    -   **Purpose**: Implements the `SpecBuilder` for `SourceSpec`.
+    -   **Functionality**: Builds the multiple `KubernetesSpec` objects required for a Drasi Source, including deployments for the `change-router`, `change-dispatcher`, `query-api`, and any provider-specific services (like a `proxy`).
+
+-   **`reaction.rs`**:
+    -   **Purpose**: Implements the `SpecBuilder` for `ReactionSpec`.
+    -   **Functionality**: Builds the `KubernetesSpec` for a Drasi Reaction. It handles creating `ConfigMap`s for query configurations and setting up the Dapr pub/sub component for receiving query results.
+
+-   **`query_container.rs`**:
+    -   **Purpose**: Implements the `SpecBuilder` for `QueryContainerSpec`.
+    -   **Functionality**: Builds the `KubernetesSpec` objects for a Query Container, including deployments for the `query-host`, `publish-api`, and `view-svc`. It also handles the creation of `PersistentVolumeClaim`s for storage profiles like RocksDB.
+
+-   **`identity.rs`**:
+    -   **Purpose**: A utility module for handling identity configurations.
+    -   **Functionality**: The `apply_identity` function takes a `KubernetesSpec` and a `ServiceIdentity` model and injects the necessary configuration. This can include adding environment variables (for secrets) or annotating `ServiceAccount`s (for workload identity).

--- a/control-planes/kubernetes_provider/src/spec_builder/CLAUDE.md
+++ b/control-planes/kubernetes_provider/src/spec_builder/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/AGENTS.md
+++ b/control-planes/mgmt_api/AGENTS.md
@@ -1,0 +1,115 @@
+# Drasi Management API
+
+## Project Overview
+
+-   **Purpose**: Central management API for the Drasi platform.
+-   **Framework**: Actix (Rust).
+-   **Key Technologies**:
+    -   MongoDB (Persistence)
+    -   Redis (Change Streams)
+    -   Dapr (Inter-service Communication)
+-   **API Version**: `v1`
+
+## Architectural Context
+
+-   **Role**: Control plane orchestrator.
+-   **Client**: Receives commands from the `drasi` CLI.
+-   **State Management**: Persists desired resource state to MongoDB.
+-   **Delegation**: Delegates implementation tasks to resource providers (e.g., `kubernetes_provider`) via Dapr pub/sub.
+
+## Internal Architecture Summary
+
+The service is built on a clean, layered architecture:
+
+-   **`src/api/`**: The HTTP layer (Actix Web). Handles routing, request deserialization, and response serialization. Delegates logic to the domain layer.
+-   **`src/domain/`**: The core business logic layer. Contains internal models and services that orchestrate all resource management workflows.
+-   **`src/persistence/`**: The data access layer (MongoDB). Abstracts database operations behind a generic Repository pattern.
+-   **`src/change_stream/`**: A utility layer for reliable, sequential messaging using Redis Streams.
+
+## Deployment
+
+-   **Method**: Deployed automatically by the Drasi CLI (`drasi init` command) using an embedded manifest.
+-   **Development Manifest**: The `deploy.yaml` file in this directory is for standalone development and testing only.
+
+## API Endpoint Summary
+
+| Endpoint | Resource | Operations |
+| :--- | :--- | :--- |
+| `/v1/sources` | Sources | `GET`, `PUT`, `DELETE`, `LIST`, `READY_WAIT` |
+| `/v1/queryContainers` | Query Containers | `GET`, `PUT`, `DELETE`, `LIST`, `READY_WAIT` |
+| `/v1/reactions` | Reactions | `GET`, `PUT`, `DELETE`, `LIST`, `READY_WAIT` |
+| `/v1/continuousQueries`| Continuous Queries | `GET`, `PUT`, `DELETE`, `LIST`, `READY_WAIT`, `WATCH` |
+| `/v1/sourceProviders` | Source Providers | `GET`, `PUT`, `DELETE`, `LIST` |
+| `/v1/reactionProviders`| Reaction Providers | `GET`, `PUT`, `DELETE`, `LIST` |
+| `/v/debug` | Debug | WebSocket |
+
+---
+
+## API Endpoint Details
+
+All standard resource endpoints (`sources`, `queryContainers`, `reactions`, `continuousQueries`) follow a consistent CRUD pattern.
+
+### Standard Resource Operations
+
+These operations apply to `sources`, `queryContainers`, `reactions`, and `continuousQueries`.
+
+*   **`PUT /{id}`**: Creates or updates a resource.
+    *   **Request Body**: A JSON object representing the resource's `spec`. The specific fields depend on the resource type (e.g., `SourceSpecDto`, `QueryContainerSpecDto`).
+    *   **Response Body**: The full resource object, including `id`, `spec`, and `status`.
+
+*   **`GET /{id}`**: Retrieves a single resource.
+    *   **Response Body**: The full resource object.
+
+*   **`GET /`**: Lists all resources of a given type.
+    *   **Response Body**: A JSON array of full resource objects.
+
+*   **`DELETE /{id}`**: Deletes a resource.
+    *   **Response**: `204 No Content` on success.
+
+*   **`GET /{id}/ready-wait`**: Blocks until the resource's status is "Ready" or a timeout occurs.
+    *   **Query Parameters**: `timeout` (integer, seconds, default: 60, max: 300).
+    *   **Response**: `200 OK` if ready, `503 Service Unavailable` if timeout is reached.
+
+### Provider Operations
+
+These operations apply to `sourceProviders` and `reactionProviders`.
+
+*   **`PUT /{id}`**: Creates or updates a provider.
+    *   **Request Body**: A `ProviderSpecDto` JSON object.
+    *   **Response Body**: The provider resource object.
+
+*   **`GET /{id}`**: Retrieves a provider.
+    *   **Response Body**: The provider resource object.
+
+*   **`GET /`**: Lists all providers.
+    *   **Response Body**: A JSON array of provider resource objects.
+
+*   **`DELETE /{id}`**: Deletes a provider.
+    *   **Response**: `204 No Content` on success.
+
+### Special Endpoints
+
+*   **`GET /v1/continuousQueries/{id}/watch`**:
+    *   **Description**: Establishes a persistent connection to stream the results of a continuous query.
+    *   **Response**: A streaming JSON array of result objects. The connection remains open as new results are available.
+
+*   **`/v1/debug`**:
+    *   **Description**: A WebSocket endpoint for interactively debugging a query without persisting it.
+    *   **Initial Message (Client -> Server)**: A `QuerySpecDto` JSON object sent as a text message to start the debug session.
+    *   **Stream (Server -> Client)**: A stream of JSON objects representing debug events and results, or an error message.
+
+---
+
+## Development
+
+### Testing and Linting
+
+*   **Run tests**: `make test`
+*   **Check formatting and style**: `make lint-check`
+
+---
+
+## Development Conventions
+
+*   Follows standard Rust conventions (`cargo fmt`, `cargo clippy`).
+*   The API is versioned under `/v1/`.

--- a/control-planes/mgmt_api/CLAUDE.md
+++ b/control-planes/mgmt_api/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/AGENTS.md
+++ b/control-planes/mgmt_api/src/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md: `control-planes/mgmt_api/src` Directory
+
+This directory contains the complete source code for the Drasi Management API service. It is the top-level entry point for understanding the application's construction and internal architecture.
+
+## Architectural Context
+
+-   **Role**: Application Crate Root.
+-   **Purpose**: To define the application's binary entry point (`main.rs`) and declare the top-level modules that make up the service. This is where all architectural layers are wired together.
+
+## Key Files
+
+-   **`main.rs`**:
+    -   **Purpose**: The main entry point for the `mgmt_api` binary.
+    -   **Key Responsibilities**:
+        -   **Initialization**: Reads environment variables for configuration (e.g., `MONGO_URI`, `REDIS_URL`).
+        -   **Connection Management**: Establishes connections to external services like Dapr and MongoDB.
+        -   **Dependency Injection**: Instantiates all the repositories (from `persistence`) and services (from `domain`). It then injects these dependencies into each other to construct the complete application logic.
+        -   **Web Server Configuration**: Configures and launches the Actix `HttpServer`. It registers all the v1 API routes (e.g., `/v1/sources`) and makes the domain service instances available to the Actix request handlers.
+
+## Subdirectories
+
+This service is organized into a clean, layered architecture, with each major component residing in its own subdirectory.
+
+-   **`api/`**:
+    -   **Purpose**: The public-facing HTTP API layer. It handles web requests and responses, using the `domain` layer to perform the actual work.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`domain/`**:
+    -   **Purpose**: The core business logic layer. It contains the internal data models and services that orchestrate all resource management workflows.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`persistence/`**:
+    -   **Purpose**: The data persistence layer. It abstracts all database interactions behind a generic Repository pattern.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`change_stream/`**:
+    -   **Purpose**: Provides an abstraction for a reliable, sequential message stream, with a concrete implementation using Redis Streams.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**

--- a/control-planes/mgmt_api/src/CLAUDE.md
+++ b/control-planes/mgmt_api/src/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/api/AGENTS.md
+++ b/control-planes/mgmt_api/src/api/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md: `control-planes/mgmt_api/src/api` Directory
+
+This directory defines the public-facing HTTP API layer for the Drasi management service. It is responsible for exposing the service's capabilities to the outside world, primarily to the `drasi` CLI.
+
+## Architectural Context
+
+-   **Role**: Web Service / API Endpoint Layer.
+-   **Purpose**: To handle incoming HTTP requests, deserialize them into Data Transfer Objects (DTOs), delegate the work to the `domain` layer, and serialize the results back into HTTP responses.
+-   **Framework**: Actix Web.
+
+## File Structure
+
+-   **`mod.rs`**: The root of the API module. Its primary function here is to define the mapping from internal `DomainError` types to the appropriate `actix_web::HttpResponse` status codes (e.g., `DomainError::NotFound` becomes a `404 Not Found` response).
+
+## Subdirectories
+
+-   **`v1/`**: Contains the complete implementation of the version 1 API. This is the most important subdirectory.
+    -   **Purpose**: It defines all the Actix route handlers for the resource endpoints (e.g., `/v1/sources`, `/v1/continuousQueries`). It orchestrates the flow of data from the web request, through the DTO and mapping layers, to the domain services, and back.
+    -   **Key Subdirectories**:
+        -   `models/`: Defines the public DTOs for the v1 API.
+        -   `mappings/`: Provides the translation logic between the v1 DTOs and the internal domain models.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**

--- a/control-planes/mgmt_api/src/api/CLAUDE.md
+++ b/control-planes/mgmt_api/src/api/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/api/v1/AGENTS.md
+++ b/control-planes/mgmt_api/src/api/v1/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md: `control-planes/mgmt_api/src/api/v1` Directory
+
+This directory implements the version 1 (`v1`) HTTP API. It is the "Routing Layer" of the service, responsible for mapping incoming HTTP requests to the correct business logic in the `domain` layer.
+
+## Architectural Context
+
+-   **Role**: API Routing and Handling Layer.
+-   **Purpose**: To define the web service endpoints, handle request/response serialization, and orchestrate calls to the domain services. This is where the HTTP protocol is translated into internal function calls.
+-   **Framework**: Actix Web.
+-   **Key Pattern**: The `mod.rs` file uses a Rust macro (`v1_crud_api!`) to generate the standard set of CRUDL (Create, Read, Update, Delete, List) and `ready-wait` endpoints for each resource. This avoids repetitive boilerplate code for common operations.
+
+## File Structure
+
+-   **`mod.rs`**:
+    -   **Purpose**: The core of the v1 API. It defines the Actix Web route handlers and configures the routing for all resources.
+    -   **Implementation**:
+        -   It defines handler modules for each resource type (e.g., `source_handlers`, `query_handlers`).
+        -   Each handler module uses the `v1_crud_api!` macro to generate its standard endpoints.
+        -   Resource-specific handlers, like `watch` for queries or the WebSocket `debug` endpoint, are defined as separate functions and added to the routing configuration.
+        -   The handler functions are responsible for deserializing request bodies into DTOs, calling the appropriate `domain` service, and serializing the result back into an `HttpResponse`.
+
+## Subdirectories
+
+-   **`models/`**:
+    -   **Purpose**: Defines the public Data Transfer Objects (DTOs) for the v1 API. These are the Rust structs that map directly to the API's JSON bodies.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`mappings/`**:
+    -   **Purpose**: Contains the translation logic to convert between the public v1 DTOs (`models/`) and the internal `domain` models.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**

--- a/control-planes/mgmt_api/src/api/v1/CLAUDE.md
+++ b/control-planes/mgmt_api/src/api/v1/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/api/v1/mappings/AGENTS.md
+++ b/control-planes/mgmt_api/src/api/v1/mappings/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md: `control-planes/mgmt_api/src/api/v1/mappings` Directory
+
+This directory contains the translation logic for converting between API Data Transfer Objects (DTOs) and the internal Domain Model objects.
+
+## Architectural Context
+
+-   **Role**: Data structure mapping layer.
+-   **Purpose**: To decouple the public-facing API data structures from the internal business logic structures. This allows the internal domain model to evolve without breaking the public v1 API contract.
+-   **Mechanism**: Implements Rust's `From` trait for bidirectional conversions.
+
+## File Structure
+
+The directory is organized by resource type, with each file responsible for the mappings of a specific resource.
+
+-   **`mod.rs`**: Declares the other files as modules and provides generic mapping implementations for the base `Resource` and `ConfigValue` types that are shared across all resources.
+-   **`providers.rs`**: Handles mappings for `SourceProvider` and `ReactionProvider` resources, including their complex nested structures like `ProviderSpec` and `JsonSchema`.
+-   **`query.rs`**: Handles mappings for `ContinuousQuery` resources (`QuerySpec`, `QueryStatus`, etc.).
+-   **`query_container.rs`**: Handles mappings for `QueryContainer` resources.
+-   **`reaction.rs`**: Handles mappings for `Reaction` resources.
+-   **`source.rs`**: Handles mappings for `Source` resources.

--- a/control-planes/mgmt_api/src/api/v1/mappings/CLAUDE.md
+++ b/control-planes/mgmt_api/src/api/v1/mappings/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/api/v1/models/AGENTS.md
+++ b/control-planes/mgmt_api/src/api/v1/models/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md: `control-planes/mgmt_api/src/api/v1/models` Directory
+
+This directory defines the public Data Transfer Objects (DTOs) for the `v1` API. These are the Rust structs that directly map to the JSON request and response bodies of the management API.
+
+## Architectural Context
+
+-   **Role**: API Data Model / DTO Layer.
+-   **Purpose**: To define the stable, versioned, public contract of the management API. These structs are what clients of the API (like the `drasi` CLI) will serialize and deserialize.
+-   **Technology**: Uses `serde` for JSON serialization/deserialization. Field attributes like `#[serde(rename_all = "camelCase")]` are used to ensure the JSON representation matches common web API conventions.
+
+## File Structure
+
+The directory is organized by resource type, with each file defining the DTOs for a specific resource.
+
+-   **`mod.rs`**: Declares the other files as modules and defines the generic `ResourceDto` and `ResourceProviderDto` wrappers. It also contains the complex but crucial definition for `ConfigValueDto`, which allows API clients to provide values either inline or as references to Kubernetes secrets.
+-   **`providers.rs`**: Defines DTOs for `SourceProvider` and `ReactionProvider` resources, including `ProviderSpecDto` and the highly detailed `JsonSchemaDto` used for configuration validation.
+-   **`query.rs`**: Defines DTOs for `ContinuousQuery` resources, such as `QuerySpecDto` and `QueryStatusDto`.
+-   **`query_container.rs`**: Defines DTOs for `QueryContainer` resources, including `QueryContainerSpecDto` and `StorageSpecDto`.
+-   **`reaction.rs`**: Defines DTOs for `Reaction` resources (`ReactionSpecDto`, `ReactionStatusDto`).
+-   **`source.rs`**: Defines DTOs for `Source` resources (`SourceSpecDto`, `SourceStatusDto`).

--- a/control-planes/mgmt_api/src/api/v1/models/CLAUDE.md
+++ b/control-planes/mgmt_api/src/api/v1/models/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/change_stream/AGENTS.md
+++ b/control-planes/mgmt_api/src/change_stream/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md: `control-planes/mgmt_api/src/change_stream` Directory
+
+This directory provides an abstraction for a reliable, sequential message stream, with a concrete implementation using Redis Streams.
+
+## Architectural Context
+
+-   **Role**: Sequential Message Stream Abstraction.
+-   **Purpose**: To provide a guaranteed, in-order message processing mechanism. This is critical for scenarios where the order of events matters, such as processing a series of updates to a single resource. It ensures that messages are processed one at a time and only the next message is delivered after the previous one has been acknowledged (`ack`).
+-   **Technology**: Redis Streams (via the `redis-rs` crate).
+
+## File Structure
+
+-   **`mod.rs`**:
+    -   **Purpose**: Defines the core abstractions for the change stream.
+    -   **Key Components**:
+        -   `SequentialChangeStream` (trait): The main interface. It defines the core methods `recv` (receive a message) and `ack` (acknowledge a message). This ensures "at-least-once" and in-order delivery semantics.
+        -   `Message<T>` (struct): A wrapper for deserialized message data that also carries distributed tracing information (`trace_parent`, `trace_state`).
+        -   `ChangeStreamError` (enum): Defines the possible error types.
+
+-   **`redis_change_stream.rs`**:
+    -   **Purpose**: Provides the concrete implementation of the `SequentialChangeStream` trait using Redis Streams.
+    -   **Key Components**:
+        -   `RedisChangeStream` (struct): The implementation struct.
+        -   **Functionality**: It uses a Redis Consumer Group to read from a stream. A background `tokio` task fetches messages in batches and puts them into a buffer. The `recv` method pulls one message from the buffer, and it will not pull the next one until the current message is acknowledged via the `ack` method. This enforces the sequential processing guarantee.
+
+-   **`tests.rs`**: Contains unit and integration tests for the Redis change stream implementation.

--- a/control-planes/mgmt_api/src/change_stream/CLAUDE.md
+++ b/control-planes/mgmt_api/src/change_stream/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/domain/AGENTS.md
+++ b/control-planes/mgmt_api/src/domain/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md: `control-planes/mgmt_api/src/domain` Directory
+
+This directory contains the core business logic and internal models for the Drasi management API. It acts as the intermediary between the public-facing `api` layer and the `persistence` layer.
+
+## Architectural Context
+
+-   **Role**: Domain Logic / Business Logic Layer.
+-   **Purpose**: To define the internal representation of Drasi resources and implement the workflows for managing them. This layer is responsible for validation, orchestration, and ensuring the integrity of the platform's state. It is completely decoupled from the web framework (`api` layer) and the database implementation (`persistence` layer).
+
+## Key Files
+
+-   **`models.rs`**:
+    -   **Purpose**: Defines the internal, canonical data structures for all Drasi resources (e.g., `SourceSpec`, `QuerySpec`, `ProviderSpec`). These are the "true" representations of the resources, distinct from the versioned DTOs in the `api` layer. Also defines the `DomainError` enum for internal error handling.
+
+-   **`mappings.rs`**:
+    -   **Purpose**: Provides the translation logic for converting internal `domain` models into the models required by the `resource_provider_api`. This is crucial for communicating with the `kubernetes_provider`.
+
+-   **`query_actor_service.rs`**:
+    -   **Purpose**: A dedicated service that encapsulates the logic for communicating with `ContinuousQuery` Dapr actors. It handles `configure`, `deprovision`, and `wait_for_ready_or_error` actor invocations.
+
+-   **`result_service.rs`**:
+    -   **Purpose**: Provides logic for streaming the results of a query. It can get a snapshot of current results from the view service and then stream subsequent real-time changes from the Redis results stream. Used by the `watch` and `debug` API endpoints.
+
+-   **`debug_service.rs`**:
+    -   **Purpose**: Implements the logic for the interactive query debugging WebSocket. It creates a temporary, "transient" query, streams its results back to the client, and ensures the query is deprovisioned when the session ends.
+
+## Subdirectories
+
+-   **`resource_services/`**:
+    -   **Purpose**: Contains the primary domain services for managing the lifecycle of all Drasi resources (Sources, Queries, etc.). It handles validation, persistence, and invoking Dapr actors on the resource provider.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`resource_provider_services/`**:
+    -   **Purpose**: Contains the domain services specifically for managing `SourceProvider` and `ReactionProvider` registrations.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**

--- a/control-planes/mgmt_api/src/domain/CLAUDE.md
+++ b/control-planes/mgmt_api/src/domain/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/domain/resource_provider_services/AGENTS.md
+++ b/control-planes/mgmt_api/src/domain/resource_provider_services/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md: `control-planes/mgmt_api/src/domain/resource_provider_services` Directory
+
+This directory contains the domain services responsible for managing the lifecycle of `SourceProvider` and `ReactionProvider` resources.
+
+## Architectural Context
+
+-   **Role**: Domain Service Layer for Providers.
+-   **Purpose**: To handle the business logic for provider registration. This includes validating the provider's specification and persisting it to the database.
+-   **Key Pattern**: It uses a generic implementation (`ResourceProviderDomainServiceImpl`) parameterized with a marker trait (`TMarker`) to handle the common logic for both source and reaction providers. Concrete types are then created using type aliases.
+
+## File Structure
+
+-   **`mod.rs`**:
+    -   **Purpose**: Defines the core generic logic for all resource provider services.
+    -   **Key Components**:
+        -   `ResourceProviderDomainService<TMarker>` (trait): The public contract for the service, defining methods like `set`, `get`, `delete`, and `list`.
+        -   `ResourceProviderDomainServiceImpl<TMarker>` (struct): The generic implementation of the service. It orchestrates calls to the persistence layer (`ResourceSpecRepository`) and runs any configured validators.
+
+-   **`source_provider_service.rs`**:
+    -   **Purpose**: Defines the concrete service for managing `SourceProvider` resources.
+    -   **Key Components**:
+        -   `SourceProviderDomainService` (type alias): A type alias for `dyn ResourceProviderDomainService<SourceProviderMarker>`.
+        -   `SourceProviderDomainServiceImpl` (type alias): A type alias for `ResourceProviderDomainServiceImpl<SourceProviderMarker>`.
+        -   `new()` (function): A constructor to create a new instance of the service, injecting the Dapr client and the persistence repository.
+
+-   **`reaction_provider_service.rs`**:
+    -   **Purpose**: Defines the concrete service for managing `ReactionProvider` resources.
+    -   **Key Components**:
+        -   `ReactionProviderDomainService` (type alias): A type alias for `dyn ResourceProviderDomainService<ReactionProviderMarker>`.
+        -   `ReactionProviderDomainServiceImpl` (type alias): A type alias for `ResourceProviderDomainServiceImpl<ReactionProviderMarker>`.
+        -   `new()` (function): A constructor for the reaction provider service.

--- a/control-planes/mgmt_api/src/domain/resource_provider_services/CLAUDE.md
+++ b/control-planes/mgmt_api/src/domain/resource_provider_services/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/domain/resource_services/AGENTS.md
+++ b/control-planes/mgmt_api/src/domain/resource_services/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md: `control-planes/mgmt_api/src/domain/resource_services` Directory
+
+This directory contains the domain services that implement the core business logic for managing all Drasi resources (Sources, Queries, etc.).
+
+## Architectural Context
+
+-   **Role**: Domain Service Layer for Resources.
+-   **Purpose**: To orchestrate the lifecycle of a resource. This includes validating its specification, persisting it, and communicating with the resource provider via Dapr actors to actualize the resource in the hosting environment.
+-   **Key Pattern**: The services use a generic, trait-based implementation (`ResourceDomainService`) to handle common CRUD and `wait_for_ready` logic. There are two distinct specializations of this pattern, located in the subdirectories.
+
+## File Structure
+
+-   **`mod.rs`**:
+    -   **Purpose**: Defines the primary `ResourceDomainService<TSpec, TStatus>` trait, which is the public contract for all services in this module. It also re-exports the concrete service types from the subdirectories for easy use by the `api` layer.
+
+## Subdirectories
+
+-   **`standard/`**:
+    -   **Purpose**: Contains services for managing "standard" Drasi resources that have a fixed, built-in implementation and do not depend on external providers.
+    -   **Resources Managed**: `ContinuousQuery`, `QueryContainer`.
+    -   **Implementation**: Uses a `StandardResourceDomainServiceImpl` that handles validation and persistence before invoking a corresponding Dapr actor (e.g., `QueryContainerResource`).
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**
+
+-   **`extensible/`**:
+    -   **Purpose**: Contains services for managing "extensible" resources. These resources are defined by `Provider` definitions and their behavior is not built-in.
+    -   **Resources Managed**: `Source`, `Reaction`.
+    -   **Implementation**: Uses an `ExtensibleResourceDomainServiceImpl`. Before persisting the resource, this service first loads the corresponding `SourceProvider` or `ReactionProvider` to validate the resource's `spec` against the provider's `config_schema`. It also populates default values from the provider definition.
+    -   **For more details, see the `AGENTS.md` file within this subdirectory.**

--- a/control-planes/mgmt_api/src/domain/resource_services/CLAUDE.md
+++ b/control-planes/mgmt_api/src/domain/resource_services/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/mgmt_api/src/persistence/AGENTS.md
+++ b/control-planes/mgmt_api/src/persistence/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md: `control-planes/mgmt_api/src/persistence` Directory
+
+This directory is the data persistence layer for the management API. It is responsible for all interactions with the database, abstracting the specific database technology and operations behind a generic Repository pattern.
+
+## Architectural Context
+
+-   **Role**: Persistence / Data Access Layer.
+-   **Purpose**: To provide a clean, consistent interface for the `domain` layer to perform CRUD (Create, Read, Update, Delete) operations on resource specifications without needing to know the details of the underlying database.
+-   **Technology**: MongoDB (via the `mongodb` crate).
+-   **Key Pattern**: Implements the Repository pattern. A generic `ResourceSpecRepositoryImpl` handles the common MongoDB operations (`find_one`, `replace_one`, `delete_one`), and this is used to create concrete repository types for each resource.
+
+## File Structure
+
+-   **`mod.rs`**:
+    -   **Purpose**: Defines the core generic repository logic.
+    -   **Key Components**:
+        -   `ResourceSpecRepository<T>` (trait): The public contract for all repositories, defining methods like `get`, `set`, `delete`, and `list`.
+        -   `ResourceSpecRepositoryImpl<T>` (struct): The generic implementation of the trait that works with any resource specification type `T`. It takes a MongoDB `Collection` and performs the database operations.
+
+-   **`source_repository.rs`**: Defines the concrete `SourceRepository` type alias and a constructor that points it to the "sources" MongoDB collection.
+-   **`reaction_repository.rs`**: Defines the `ReactionRepository` for the "reactions" collection.
+-   **`query_repository.rs`**: Defines the `QueryRepository` for the "queries" collection.
+-   **`query_container_repository.rs`**: Defines the `QueryContainerRepository` for the "query-containers" collection.
+-   **`provider_repository.rs`**: Defines the `ProviderRepository`. Note that this single repository is used for both `SourceProvider` and `ReactionProvider` resources, which are stored in separate collections configured at runtime.

--- a/control-planes/mgmt_api/src/persistence/CLAUDE.md
+++ b/control-planes/mgmt_api/src/persistence/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/control-planes/resource_provider_api/AGENTS.md
+++ b/control-planes/resource_provider_api/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md: `control-planes/resource_provider_api` Directory
+
+## Architectural Context
+
+-   **Type**: Rust Library Crate.
+-   **Role**: Shared communication contract between the `mgmt_api` and resource providers (e.g., `kubernetes_provider`).
+-   **Purpose**: Defines the stable, shared data structures (`models`) for inter-service communication, enabling a pluggable provider architecture.
+-   **Consumers**: `mgmt_api`, `kubernetes_provider`.
+
+## Code Structure
+
+-   **`Cargo.toml`**: Defines crate metadata and dependencies (`serde`).
+-   **`src/lib.rs`**: Crate root. Exposes the `models` module.
+-   **`src/models.rs`**: **Primary file.** Defines all shared data structures (e.g., `SourceSpec`, `ReactionSpec`) used for API calls between control plane components.
+
+## Development
+
+-   **Build**: `cargo build`
+-   **Test**: `cargo test`
+-   **Check**: `cargo check`

--- a/control-planes/resource_provider_api/CLAUDE.md
+++ b/control-planes/resource_provider_api/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
# Description

Add `AGENTS.md` files at various levels of the directory structure to provide relevant context to coding agents.

Works for:
- Gemini CLI
- Codex (OpenAI)
- Github Copilot Coding Agent
- Web-based Copilot Agent (SWE agent)

Does not work for:
- Github Copilot inline completions (VS Code / Visual Studio)
- Claude Code (Mitigated by creating a symlink called `CLAUDE.md` for each `AGENT.md` file)

## Type of change

- [ ] This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- [ ] This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- [X] This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).
