### PR TITLE
Relabel middleware

### DIFF
--- a/query-container/query-host/src/main.rs
+++ b/query-container/query-host/src/main.rs
@@ -101,6 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut middleware_registry = MiddlewareTypeRegistry::new();
     middleware_registry.register(Arc::new(drasi_middleware::map::MapFactory::new()));
     middleware_registry.register(Arc::new(drasi_middleware::unwind::UnwindFactory::new()));
+    middleware_registry.register(Arc::new(drasi_middleware::relabel::RelabelMiddlewareFactory::new()));
     middleware_registry.register(Arc::new(drasi_middleware::decoder::DecoderFactory::new()));
     middleware_registry.register(Arc::new(
         drasi_middleware::parse_json::ParseJsonFactory::new(),

--- a/query-container/query-host/src/main.rs
+++ b/query-container/query-host/src/main.rs
@@ -101,7 +101,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut middleware_registry = MiddlewareTypeRegistry::new();
     middleware_registry.register(Arc::new(drasi_middleware::map::MapFactory::new()));
     middleware_registry.register(Arc::new(drasi_middleware::unwind::UnwindFactory::new()));
-    middleware_registry.register(Arc::new(drasi_middleware::relabel::RelabelMiddlewareFactory::new()));
+    middleware_registry.register(Arc::new(
+        drasi_middleware::relabel::RelabelMiddlewareFactory::new(),
+    ));
     middleware_registry.register(Arc::new(drasi_middleware::decoder::DecoderFactory::new()));
     middleware_registry.register(Arc::new(
         drasi_middleware::parse_json::ParseJsonFactory::new(),


### PR DESCRIPTION
This pull request updates the `drasi-core` submodule and adds a new middleware to the middleware registry in the `query-host` service. The main focus is to integrate the new `RelabelMiddlewareFactory` from the `drasi_middleware` crate.

**Middleware registration:**
- Registered the new `RelabelMiddlewareFactory` in the `MiddlewareTypeRegistry` within `query-host/src/main.rs`, enabling support for relabeling middleware in the query host.

**Dependency update:**
- Updated the `drasi-core` submodule to the latest commit, likely pulling in new features and fixes required for the new middleware.