### PR TITLE
Update Debezium & Azure Identity libraries

### DIFF
--- a/cli/installers/resources/default-source-providers.yaml
+++ b/cli/installers/resources/default-source-providers.yaml
@@ -60,8 +60,6 @@ spec:
       - database
       - host
       - port
-      - password
-      - user
       - tables
 ---
 apiVersion: v1

--- a/sources/relational/debezium-reactivator/pom.xml
+++ b/sources/relational/debezium-reactivator/pom.xml
@@ -30,7 +30,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <version.debezium>2.7.3.Final</version.debezium>
+    <version.debezium>3.2.2.Final</version.debezium>
   </properties>
 
   <dependencies>

--- a/sources/relational/debezium-reactivator/pom.xml
+++ b/sources/relational/debezium-reactivator/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.9.2</version>
+      <version>1.18.0</version>
     </dependency>
 
     <dependency>

--- a/sources/relational/debezium-reactivator/src/main/java/io/drasi/RelationalChangeMonitor.java
+++ b/sources/relational/debezium-reactivator/src/main/java/io/drasi/RelationalChangeMonitor.java
@@ -134,6 +134,8 @@ public class RelationalChangeMonitor implements ChangeMonitor {
                 .with("tombstones.on.delete", false)
                 // Used as a namespace for the connector storage.
                 .with("topic.prefix", cleanSourceId)
+
+                .with("errors.max.retries", "3")
             .build();
     }
 
@@ -141,7 +143,7 @@ public class RelationalChangeMonitor implements ChangeMonitor {
         final Properties props = config.asProperties();
         engine = DebeziumEngine.create(Json.class)
                 .using(props)
-                .using(OffsetCommitPolicy.always())
+                .using(OffsetCommitPolicy.always())                
                 .using((success, message, error) -> {
                     if (!success && error != null) {
                         log.error("Error in Debezium engine: {}", error.getMessage());

--- a/sources/relational/debezium-reactivator/src/main/java/io/drasi/databases/AzureIdentityTokenFetcher.java
+++ b/sources/relational/debezium-reactivator/src/main/java/io/drasi/databases/AzureIdentityTokenFetcher.java
@@ -1,0 +1,25 @@
+package io.drasi.databases;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.core.credential.TokenRequestContext;
+
+public class AzureIdentityTokenFetcher {
+    private static final Logger log = LoggerFactory.getLogger(AzureIdentityTokenFetcher.class);
+
+    private static final String SCOPE = "https://ossrdbms-aad.database.windows.net/.default";
+    
+    public String getToken() {
+
+        log.info("Fetching Azure AD token");
+        
+        // Fetch Azure AD token
+        var credential = new DefaultAzureCredentialBuilder().build();
+        var tokenContext = new TokenRequestContext().addScopes(SCOPE);
+        String accessToken = credential.getToken(tokenContext).block().getToken();
+
+        return accessToken;
+    }
+}

--- a/sources/relational/sql-proxy/pom.xml
+++ b/sources/relational/sql-proxy/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.4</version>
+      <version>42.7.8</version>
     </dependency>
 
     <dependency>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.9.2</version>
+      <version>1.18.0</version>
     </dependency>
 
     <dependency>

--- a/sources/relational/sql-proxy/src/main/java/io/drasi/AzureIdentityPostgreSQLConnection.java
+++ b/sources/relational/sql-proxy/src/main/java/io/drasi/AzureIdentityPostgreSQLConnection.java
@@ -1,0 +1,52 @@
+package io.drasi;
+
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.core.credential.AccessToken;
+import io.drasi.source.sdk.SourceProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class AzureIdentityPostgreSQLConnection {
+
+    private static final Logger log = LoggerFactory.getLogger(AzureIdentityPostgreSQLConnection.class);
+    private static final String POSTGRES_SCOPE = "https://ossrdbms-aad.database.windows.net/.default";
+
+    public static Connection getConnection() throws SQLException {
+        try {
+            log.info("Using Azure Identity for PostgreSQL authentication");
+
+            // Get access token using DefaultAzureCredential
+            var credential = new DefaultAzureCredentialBuilder().build();
+            AccessToken token = credential.getTokenSync(
+                new com.azure.core.credential.TokenRequestContext()
+                    .addScopes(POSTGRES_SCOPE)
+            );
+
+            // Set up connection properties
+            var props = new Properties();
+            props.setProperty("user", SourceProxy.GetConfigValue("user"));
+            props.setProperty("password", token.getToken());
+
+            // For Azure PostgreSQL with managed identity, we need to set these additional properties
+            props.setProperty("ssl", "true");
+            props.setProperty("sslmode", "require");
+
+            String connectionUrl = "jdbc:postgresql://"
+                + SourceProxy.GetConfigValue("host") + ":"
+                + SourceProxy.GetConfigValue("port") + "/"
+                + SourceProxy.GetConfigValue("database");
+
+            log.debug("Connecting to PostgreSQL using Azure Identity token");
+            return DriverManager.getConnection(connectionUrl, props);
+
+        } catch (Exception e) {
+            log.error("Failed to authenticate using Azure Identity", e);
+            throw new SQLException("Azure Identity authentication failed", e);
+        }
+    }
+}

--- a/sources/relational/sql-proxy/src/main/java/io/drasi/ResultStream.java
+++ b/sources/relational/sql-proxy/src/main/java/io/drasi/ResultStream.java
@@ -69,6 +69,13 @@ public class ResultStream implements BootstrapStream {
     private static Connection getConnection() throws SQLException {
         switch (SourceProxy.GetConfigValue("connector")) {
             case "PostgreSQL":
+                // Check if Azure Identity should be used
+                String identityType = SourceProxy.GetConfigValue("IDENTITY_TYPE");
+                if ("MicrosoftEntraWorkloadID".equals(identityType)) {
+                    return AzureIdentityPostgreSQLConnection.getConnection();
+                }
+
+                // Default PostgreSQL connection with username/password
                 var propsPG = new Properties();
                 propsPG.setProperty("user", SourceProxy.GetConfigValue("user"));
                 propsPG.setProperty("password", SourceProxy.GetConfigValue("password"));


### PR DESCRIPTION
This pull request introduces support for authenticating to Azure PostgreSQL databases using Azure Identity (Microsoft Entra Workload ID) in both the Debezium reactivator and SQL proxy components. It also updates several dependencies and adds logic to select authentication mode based on configuration.

**Azure Identity Integration:**

* Added `AzureIdentityTokenFetcher` and `AzureIdentityPostgreSQLConnection` classes to fetch Azure AD tokens and establish PostgreSQL connections using Azure Identity, enabling managed identity authentication. [[1]](diffhunk://#diff-17488154f74a9c9c4614289dee019dad449322e026dff132ad398654ca87e784R1-R25) [[2]](diffhunk://#diff-bbe7a51bf2df8216619cd2b1fc289b9e0c62dfe694d6abd3a200fa24fa850da6R1-R52)
* Updated the Debezium reactivator (`PostgreSql.java`) and SQL proxy (`ResultStream.java`) to use Azure Identity for authentication when `IDENTITY_TYPE` is set to `MicrosoftEntraWorkloadID`, including setting the token as the database password and enforcing SSL. [[1]](diffhunk://#diff-21809a017dce0750f11de9484fd2e8edc6f495d46f775631eb6bc6c8a687829eL107-R122) [[2]](diffhunk://#diff-3bf6025a2a9d7303bbc3bb129f2e41a5c7e69067021c3fd64eee65cbc3fabc8bR72-R78)

**Dependency Updates:**

* Upgraded `debezium` from `2.7.3.Final` to `3.2.2.Final` and `azure-identity` from `1.9.2` to `1.18.0` in relevant Maven files for compatibility with Azure Identity features. [[1]](diffhunk://#diff-c31c404751f54d4170da59c7237804068dfb5c8575e1eb6d72397993c9208fd5L33-R33) [[2]](diffhunk://#diff-c31c404751f54d4170da59c7237804068dfb5c8575e1eb6d72397993c9208fd5L72-R72) [[3]](diffhunk://#diff-e2ba3e04ed17cde245dc36e9a3c7fa6bab899664c69929dceadcb16ef6d0e731L63-R63)
* Updated PostgreSQL JDBC driver from `42.7.4` to `42.7.8` for the SQL proxy.

**Configuration Improvements:**

* Added error retry configuration (`errors.max.retries`) to the Debezium connector setup for improved reliability.

**YAML Spec Simplification:**

* Removed `password` and `user` fields from the default source provider spec, reflecting the move to token-based authentication for Azure.