### PR TITLE
fix: update Rust version in debug Dockerfiles and fix docs

### DIFF
--- a/.github/instructions/control-planes.md
+++ b/.github/instructions/control-planes.md
@@ -57,7 +57,7 @@ control-planes/
 make docker-build
 
 # Debug builds with shell access
-make docker-build-debug
+make docker-build BUILD_CONFIG=debug
 
 # Build specific component
 make -C mgmt_api docker-build

--- a/.github/instructions/query-container.md
+++ b/.github/instructions/query-container.md
@@ -50,7 +50,7 @@ query-container/
 make docker-build
 
 # Build debug versions
-make docker-build-debug
+make docker-build BUILD_CONFIG=debug
 
 # Build specific service
 make -C publish-api docker-build

--- a/control-planes/kubernetes_provider/Dockerfile.debug
+++ b/control-planes/kubernetes_provider/Dockerfile.debug
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder 
+FROM rust:1.86-bullseye as builder
 # rust:1.81-bullseye
 RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev
 

--- a/control-planes/mgmt_api/Dockerfile.debug
+++ b/control-planes/mgmt_api/Dockerfile.debug
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
+FROM rust:1.86-bullseye as builder
 # rust:1.81-bullseye
 RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev
 

--- a/docs/contributing/contributing-code/contributing-code-building/README.md
+++ b/docs/contributing/contributing-code/contributing-code-building/README.md
@@ -27,9 +27,9 @@ If you wish to override the default (latest) image tag, you can use the `DOCKER_
 make docker-build DOCKER_TAG_VERSION="v1"
 ```
 
-If you wish to build images that support opening a terminal, you can use the `docker-build-debug` target to build the images. 
+If you wish to build images that support opening a terminal, you can use the `docker-build BUILD_CONFIG=debug` target to build the images.
 ```sh
-make docker-build-debug
+make docker-build BUILD_CONFIG=debug
 ```
 
 If you are using Kind in your development workflow, you can load the built images to your kind cluster using the `kind-load` target:

--- a/sources/kubernetes/kubernetes-proxy/Dockerfile.debug
+++ b/sources/kubernetes/kubernetes-proxy/Dockerfile.debug
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
+FROM rust:1.86-bullseye as builder
 # rust:1.81-bullseye
 RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && apt-get clean
 

--- a/sources/kubernetes/kubernetes-reactivator/Dockerfile.debug
+++ b/sources/kubernetes/kubernetes-reactivator/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM rust@sha256:8fae3b1a63a4dcfb6cf277a49fb5967ccbf479b9e9cee4588a077a9cb216e6d4 as builder
+FROM rust:1.86-bullseye as builder
 # rust:1.81-bullseye
 RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && apt-get clean
 


### PR DESCRIPTION
# Description

  This PR fixes build failures when using `BUILD_CONFIG=debug` by
   updating outdated Rust versions in debug Dockerfiles and
  correcting documentation references.

  **Changes made:**
  - Updated 4 `Dockerfile.debug` files from Rust 1.81 to Rust
  1.86-bullseye to resolve dependency compatibility issues
  - Fixed documentation to use correct `make docker-build
  BUILD_CONFIG=debug` syntax instead of non-existent
  `docker-build-debug` target

  **Files affected:**
  - `control-planes/mgmt_api/Dockerfile.debug`
  - `control-planes/kubernetes_provider/Dockerfile.debug`
  - `sources/kubernetes/kubernetes-reactivator/Dockerfile.debug`
  - `sources/kubernetes/kubernetes-proxy/Dockerfile.debug`
  - Documentation files in `/docs/` and `/.github/instructions/`

  ## Type of change

  - This pull request fixes a bug in Drasi and has an associated issue
  issue (https://github.com/drasi-project/drasi-platform/issues/316).

  Fixes: #316
