### PR TITLE
MCP Reaction: Correction for MCP resource notification spec

### DIFF
--- a/reactions/mcp/README.md
+++ b/reactions/mcp/README.md
@@ -80,7 +80,7 @@ drasi://query/{queryId}
 
 1. Client connects to the MCP server via SSE
 2. Client subscribes to specific query resources using `resources/subscribe`
-3. When Drasi sends change events for subscribed queries, the server sends `notifications/{query}/added`, `notifications/{query}/updated` and `notifications/{query}/deleted` to clients
+3. When Drasi sends change events for subscribed queries, the server sends standardized `notifications/resources/updated` notifications with the resource URI, operation type, and data
 
 ## Development
 
@@ -108,5 +108,5 @@ This implementation follows the MCP specification and supports:
 - **Legacy SSE Transport** (2024-11-05): Backward compatibility support
 - **Session Management**: Proper session ID generation and tracking
 - **Resource Management**: Dynamic resource registration and subscription
-- **Real-time Notifications**: Both custom query-specific and standard MCP notifications
+- **Real-time Notifications**: Standard MCP `notifications/resources/updated` with structured payload containing URI, operation, and data
 - **Error Handling**: Comprehensive error responses with proper JSON-RPC format

--- a/reactions/mcp/src/index.ts
+++ b/reactions/mcp/src/index.ts
@@ -239,8 +239,12 @@ async function notifyResourceUpdated(queryId: string, type: 'added' | 'updated' 
                 // Send notification through the MCP server
                 await transport.send({
                     jsonrpc: '2.0',
-                    method: `notifications/${queryId}/${type}`,
-                    params: data
+                    method: 'notifications/resources/updated',
+                    params: {
+                        uri: uri,
+                        operation: type,
+                        data: data
+                    }
                 });
                 console.log(`Sent ${type} notification for query ${queryId} to session ${sessionId}`);            
             } catch (error) {


### PR DESCRIPTION
This pull request standardizes the notification format for resource updates in the MCP server. Instead of sending custom query-specific notifications, the server now emits a unified `notifications/resources/updated` event with a structured payload. This change improves consistency and aligns with the MCP specification.

**Real-time notification standardization:**

* Updated the notification event sent to clients from custom `notifications/{query}/added`, `notifications/{query}/updated`, and `notifications/{query}/deleted` events to a standardized `notifications/resources/updated` event, which includes the resource URI, operation type, and data. (`reactions/mcp/README.md`)
* Updated the implementation to send `notifications/resources/updated` notifications with a structured payload containing `uri`, `operation`, and `data` fields, replacing the previous query-specific event format. (`reactions/mcp/src/index.ts`)
* Updated documentation to clarify that only standard MCP notifications are sent, removing references to custom query-specific notifications. (`reactions/mcp/README.md`)