### PR TITLE
Skip vector store e2e tests when creds unavailable

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -404,4 +404,13 @@ jobs:
           E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL: ${{ secrets.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL }}
         run: npm test
 
-  
+      - name: Report vectorstore test status
+        if: always()
+        run: |
+          if [ -z "${{ secrets.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY }}" ]; then
+            echo "::notice::Vectorstore tests were skipped (no OpenAI credentials available). This is expected for fork-based PRs."
+          else
+            echo "::notice::Vectorstore tests were executed with Azure OpenAI credentials."
+          fi
+
+

--- a/e2e-tests/08-sync-qdrant-vectorstore-scenario/qdrant-vectorstore.test.js
+++ b/e2e-tests/08-sync-qdrant-vectorstore-scenario/qdrant-vectorstore.test.js
@@ -152,29 +152,39 @@ async function verifyDocumentInQdrant(port, collectionName, documentId) {
 }
 
 beforeAll(async () => {
+  // Check if Azure OpenAI credentials are available
+  const azureKey = process.env.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY;
+  const azureEndpoint = process.env.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_ENDPOINT;
+  const azureModel = process.env.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL;
+
+  const hasSecrets = azureKey && azureEndpoint && azureModel;
+
+  if (!hasSecrets) {
+    console.warn(`
+┌─────────────────────────────────────────────────────────────────┐
+│ ⚠️  SKIPPING QDRANT VECTORSTORE E2E TESTS                       │
+├─────────────────────────────────────────────────────────────────┤
+│ Azure OpenAI credentials are not available.                     │
+│ This is expected for fork-based pull requests.                  │
+│                                                                  │
+│ These tests will run automatically when:                        │
+│  • PR is merged to main repository                              │
+│  • PR is created from a branch (not a fork)                     │
+│                                                                  │
+│ Missing environment variables:                                  │
+${!azureKey ? '│  ✗ E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY                 │\n' : ''}${!azureEndpoint ? '│  ✗ E2E_SYNC_VECTORSTORE_AZURE_OPENAI_ENDPOINT            │\n' : ''}${!azureModel ? '│  ✗ E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL     │\n' : ''}└─────────────────────────────────────────────────────────────────┘
+    `);
+    return; // Skip all setup
+  }
+
+  console.log(`Azure OpenAI configured: endpoint=${azureEndpoint}, model=${azureModel}`);
+
   // Load resources
   const infraResources = yaml.loadAll(fs.readFileSync(resourcesFilePath, 'utf8'));
   const sources = yaml.loadAll(fs.readFileSync(sourcesFilePath, 'utf8'));
   const queries = yaml.loadAll(fs.readFileSync(queriesFilePath, 'utf8'));
   const reactionProvider = yaml.loadAll(fs.readFileSync(reactionProviderFilePath, 'utf8'));
   const reactions = yaml.loadAll(fs.readFileSync(reactionsFilePath, 'utf8'));
-
-  // Replace Azure OpenAI configuration from environment variables
-  const azureKey = process.env.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY;
-  const azureEndpoint = process.env.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_ENDPOINT;
-  const azureModel = process.env.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL;
-  
-  if (!azureKey) {
-    throw new Error("E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY environment variable is required");
-  }
-  if (!azureEndpoint) {
-    throw new Error("E2E_SYNC_VECTORSTORE_AZURE_OPENAI_ENDPOINT environment variable is required");
-  }
-  if (!azureModel) {
-    throw new Error("E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL environment variable is required");
-  }
-  
-  console.log(`Azure OpenAI configured: endpoint=${azureEndpoint}, model=${azureModel}`);
   
   // Update secret in resources
   infraResources.forEach(resource => {
@@ -319,7 +329,12 @@ afterAll(async () => {
   }
 });
 
-describe("Qdrant Vector Store E2E Tests", () => {
+// Skip entire test suite if Azure OpenAI credentials are not available
+const describeOrSkip = process.env.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY
+  ? describe
+  : describe.skip;
+
+describeOrSkip("Qdrant Vector Store E2E Tests", () => {
   test("Initial state sync - Simple query", async () => {
     console.log("Verifying initial state sync for simple products query in Qdrant...");
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -12,6 +12,41 @@
 npm test
 ```
 
+## Vectorstore Tests (Scenarios 07 & 08)
+
+Tests in `07-sync-inmemory-vectorstore-scenario` and `08-sync-qdrant-vectorstore-scenario` require Azure OpenAI credentials to generate embeddings.
+
+### Running Vectorstore Tests Locally
+
+```bash
+export E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY="your-azure-openai-key"
+export E2E_SYNC_VECTORSTORE_AZURE_OPENAI_ENDPOINT="https://your-instance.openai.azure.com/"
+export E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL="text-embedding-3-large"
+npm test
+```
+
+### Fork-Based Pull Requests
+
+These tests are **automatically skipped** for fork-based pull requests (GitHub secrets are not available to forks for security reasons).
+
+When credentials are missing, you'll see a clear warning message:
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ ⚠️  SKIPPING VECTORSTORE E2E TESTS                              │
+├─────────────────────────────────────────────────────────────────┤
+│ Azure OpenAI credentials are not available.                     │
+│ This is expected for fork-based pull requests.                  │
+│                                                                  │
+│ These tests will run automatically when:                        │
+│  • PR is merged to main repository                              │
+│  • PR is created from a branch (not a fork)                     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+This is **normal and expected** - your PR can still pass CI without these tests. The vectorstore tests will run automatically when:
+- Your PR is merged to the main repository
+- Your PR is created from a branch in the main repository (not a fork)
+
 ## Tools
 
 To manually recreate a clean test cluster and not run any tests run the following


### PR DESCRIPTION
# Description

Skip vector store e2e tests when creds unavailable

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).
