### PR TITLE
Enable vector store e2e tests for fork contributors with mock embedding service

### DIFF
--- a/e2e-tests/08-sync-qdrant-vectorstore-scenario/qdrant-vectorstore.test.js
+++ b/e2e-tests/08-sync-qdrant-vectorstore-scenario/qdrant-vectorstore.test.js
@@ -24,6 +24,11 @@ const SignalrFixture = require("../fixtures/signalr-fixture");
 const { waitFor } = require('../fixtures/infrastructure');
 const http = require('http');
 const crypto = require('crypto');
+const {
+  setupMockEmbeddingService,
+  deleteMockEmbeddingService,
+  updateReactionsForMock
+} = require('../fixtures/deploy-mock-embedding');
 
 // Resource file paths
 const resourcesFilePath = __dirname + '/resources.yaml';
@@ -38,6 +43,7 @@ let dbClient;
 let qdrantPortForward;
 let qdrantPort; // Store the port separately
 let signalrFixture;
+let usingMockEmbeddings = false;
 
 // Helper function to generate deterministic GUID from string key (matching C# SHA-256 logic)
 function generateDeterministicGuid(key) {
@@ -160,24 +166,31 @@ beforeAll(async () => {
   const hasSecrets = azureKey && azureEndpoint && azureModel;
 
   if (!hasSecrets) {
-    console.warn(`
+    console.log(`
 ┌─────────────────────────────────────────────────────────────────┐
-│ ⚠️  SKIPPING QDRANT VECTORSTORE E2E TESTS                       │
+│ ℹ️  USING MOCK EMBEDDING SERVICE                                │
 ├─────────────────────────────────────────────────────────────────┤
 │ Azure OpenAI credentials are not available.                     │
-│ This is expected for fork-based pull requests.                  │
+│ Deploying mock embedding service for testing.                   │
 │                                                                  │
-│ These tests will run automatically when:                        │
-│  • PR is merged to main repository                              │
-│  • PR is created from a branch (not a fork)                     │
+│ This allows fork contributors to test the vector store pipeline │
+│ with deterministic (hash-based) embeddings.                     │
 │                                                                  │
-│ Missing environment variables:                                  │
-${!azureKey ? '│  ✗ E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY                 │\n' : ''}${!azureEndpoint ? '│  ✗ E2E_SYNC_VECTORSTORE_AZURE_OPENAI_ENDPOINT            │\n' : ''}${!azureModel ? '│  ✗ E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL     │\n' : ''}└─────────────────────────────────────────────────────────────────┘
+│ Note: Mock embeddings test the pipeline integration, not        │
+│ semantic quality. Real embeddings are tested when credentials   │
+│ are available.                                                   │
+└─────────────────────────────────────────────────────────────────┘
     `);
-    return; // Skip all setup
-  }
 
-  console.log(`Azure OpenAI configured: endpoint=${azureEndpoint}, model=${azureModel}`);
+    // Deploy mock embedding service
+    const mockReady = await setupMockEmbeddingService('drasi-test');
+    if (!mockReady) {
+      throw new Error('Failed to setup mock embedding service');
+    }
+    usingMockEmbeddings = true;
+  } else {
+    console.log(`Azure OpenAI configured: endpoint=${azureEndpoint}, model=${azureModel}`);
+  }
 
   // Load resources
   const infraResources = yaml.loadAll(fs.readFileSync(resourcesFilePath, 'utf8'));
@@ -195,18 +208,25 @@ ${!azureKey ? '│  ✗ E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY                 �
     }
   });
   
-  // Update reactions with environment-specific values
-  reactions.forEach(reaction => {
-    if (reaction.spec?.properties?.embeddingApiKey === '${E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY}') {
-      reaction.spec.properties.embeddingApiKey = azureKey;
-    }
-    if (reaction.spec?.properties?.embeddingEndpoint === '${E2E_SYNC_VECTORSTORE_AZURE_OPENAI_ENDPOINT}') {
-      reaction.spec.properties.embeddingEndpoint = azureEndpoint;
-    }
-    if (reaction.spec?.properties?.embeddingModel === '${E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL}') {
-      reaction.spec.properties.embeddingModel = azureModel;
-    }
-  });
+  // Update reactions with embedding service configuration
+  if (usingMockEmbeddings) {
+    // Use mock embedding service
+    console.log('Configuring reactions to use mock embedding service...');
+    updateReactionsForMock(reactions);
+  } else {
+    // Use real Azure OpenAI
+    reactions.forEach(reaction => {
+      if (reaction.spec?.properties?.embeddingApiKey === '${E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY}') {
+        reaction.spec.properties.embeddingApiKey = azureKey;
+      }
+      if (reaction.spec?.properties?.embeddingEndpoint === '${E2E_SYNC_VECTORSTORE_AZURE_OPENAI_ENDPOINT}') {
+        reaction.spec.properties.embeddingEndpoint = azureEndpoint;
+      }
+      if (reaction.spec?.properties?.embeddingModel === '${E2E_SYNC_VECTORSTORE_AZURE_OPENAI_EMBEDDING_MODEL}') {
+        reaction.spec.properties.embeddingModel = azureModel;
+      }
+    });
+  }
 
   resourcesToCleanup = [...infraResources, ...sources, ...queries, ...reactionProvider, ...reactions];
 
@@ -327,14 +347,16 @@ afterAll(async () => {
     await deleteResources(resourcesToCleanup);
     console.log("Teardown complete.");
   }
+
+  // Clean up mock embedding service if it was deployed
+  if (usingMockEmbeddings) {
+    console.log("Cleaning up mock embedding service...");
+    await deleteMockEmbeddingService();
+  }
 });
 
-// Skip entire test suite if Azure OpenAI credentials are not available
-const describeOrSkip = process.env.E2E_SYNC_VECTORSTORE_AZURE_OPENAI_KEY
-  ? describe
-  : describe.skip;
-
-describeOrSkip("Qdrant Vector Store E2E Tests", () => {
+// Tests always run - either with real Azure OpenAI or mock embedding service
+describe("Qdrant Vector Store E2E Tests", () => {
   test("Initial state sync - Simple query", async () => {
     console.log("Verifying initial state sync for simple products query in Qdrant...");
 

--- a/e2e-tests/fixtures/deploy-mock-embedding.js
+++ b/e2e-tests/fixtures/deploy-mock-embedding.js
@@ -1,0 +1,320 @@
+/**
+ * Copyright 2025 The Drasi Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Mock Embedding Service Deployment Helper
+ *
+ * This module provides functions to build, load, and deploy the mock embedding
+ * service for e2e tests when Azure OpenAI credentials are not available.
+ */
+
+const cp = require('child_process');
+const path = require('path');
+const yaml = require('js-yaml');
+const fs = require('fs');
+const { waitFor, waitForChildProcess } = require('./infrastructure');
+
+const MOCK_SERVICE_DIR = path.join(__dirname, 'mock-embedding-service');
+const MOCK_IMAGE_NAME = 'drasi-project/mock-embedding-service';
+const MOCK_IMAGE_TAG = 'latest';
+const MOCK_SERVICE_NAME = 'mock-embedding-service';
+const MOCK_SERVICE_NAMESPACE = 'default';
+
+/**
+ * Build the mock embedding service Docker image
+ *
+ * @returns {Promise<void>}
+ */
+async function buildMockEmbeddingImage() {
+  console.log('Building mock embedding service Docker image...');
+
+  return new Promise((resolve, reject) => {
+    const buildProcess = cp.spawn('docker', [
+      'build',
+      '-t', `${MOCK_IMAGE_NAME}:${MOCK_IMAGE_TAG}`,
+      MOCK_SERVICE_DIR
+    ], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    buildProcess.stdout.on('data', (data) => {
+      stdout += data.toString();
+      console.log(`[docker build] ${data.toString().trim()}`);
+    });
+
+    buildProcess.stderr.on('data', (data) => {
+      stderr += data.toString();
+      // Docker build often outputs progress to stderr, so just log it
+      console.log(`[docker build] ${data.toString().trim()}`);
+    });
+
+    buildProcess.on('close', (code) => {
+      if (code === 0) {
+        console.log('Mock embedding service image built successfully.');
+        resolve();
+      } else {
+        reject(new Error(`Docker build failed with code ${code}: ${stderr}`));
+      }
+    });
+
+    buildProcess.on('error', (err) => {
+      reject(new Error(`Failed to start docker build: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Load the mock embedding service image into the Kind cluster
+ *
+ * @param {string} clusterName - The name of the Kind cluster
+ * @returns {Promise<void>}
+ */
+async function loadMockEmbeddingImageToKind(clusterName = 'drasi-test') {
+  console.log(`Loading mock embedding service image into Kind cluster '${clusterName}'...`);
+
+  return new Promise((resolve, reject) => {
+    const loadProcess = cp.spawn('kind', [
+      'load',
+      'docker-image',
+      `${MOCK_IMAGE_NAME}:${MOCK_IMAGE_TAG}`,
+      '--name', clusterName
+    ], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    let stderr = '';
+
+    loadProcess.stdout.on('data', (data) => {
+      console.log(`[kind load] ${data.toString().trim()}`);
+    });
+
+    loadProcess.stderr.on('data', (data) => {
+      stderr += data.toString();
+      console.log(`[kind load] ${data.toString().trim()}`);
+    });
+
+    loadProcess.on('close', (code) => {
+      if (code === 0) {
+        console.log('Mock embedding service image loaded into Kind cluster.');
+        resolve();
+      } else {
+        reject(new Error(`Kind load failed with code ${code}: ${stderr}`));
+      }
+    });
+
+    loadProcess.on('error', (err) => {
+      reject(new Error(`Failed to start kind load: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Deploy the mock embedding service to the Kubernetes cluster
+ *
+ * @returns {Promise<void>}
+ */
+async function deployMockEmbeddingService() {
+  console.log('Deploying mock embedding service to Kubernetes...');
+
+  const deploymentPath = path.join(MOCK_SERVICE_DIR, 'deployment.yaml');
+
+  return new Promise((resolve, reject) => {
+    const applyProcess = cp.spawn('kubectl', [
+      'apply',
+      '-f', deploymentPath
+    ], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    let stderr = '';
+
+    applyProcess.stdout.on('data', (data) => {
+      console.log(`[kubectl apply] ${data.toString().trim()}`);
+    });
+
+    applyProcess.stderr.on('data', (data) => {
+      stderr += data.toString();
+      console.error(`[kubectl apply] ${data.toString().trim()}`);
+    });
+
+    applyProcess.on('close', (code) => {
+      if (code === 0) {
+        console.log('Mock embedding service deployed.');
+        resolve();
+      } else {
+        reject(new Error(`kubectl apply failed with code ${code}: ${stderr}`));
+      }
+    });
+
+    applyProcess.on('error', (err) => {
+      reject(new Error(`Failed to start kubectl apply: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Wait for the mock embedding service to be ready
+ *
+ * @param {number} timeoutMs - Timeout in milliseconds
+ * @returns {Promise<boolean>}
+ */
+async function waitForMockServiceReady(timeoutMs = 60000) {
+  console.log('Waiting for mock embedding service to be ready...');
+
+  return waitFor({
+    actionFn: async () => {
+      try {
+        const result = cp.execSync(
+          `kubectl get deployment ${MOCK_SERVICE_NAME} -n ${MOCK_SERVICE_NAMESPACE} -o jsonpath='{.status.readyReplicas}'`,
+          { encoding: 'utf8', timeout: 5000 }
+        ).trim();
+        return parseInt(result) >= 1;
+      } catch (error) {
+        return false;
+      }
+    },
+    predicateFn: (ready) => ready === true,
+    timeoutMs: timeoutMs,
+    pollIntervalMs: 2000,
+    description: 'mock embedding service to be ready'
+  });
+}
+
+/**
+ * Delete the mock embedding service from the Kubernetes cluster
+ *
+ * @returns {Promise<void>}
+ */
+async function deleteMockEmbeddingService() {
+  console.log('Deleting mock embedding service from Kubernetes...');
+
+  const deploymentPath = path.join(MOCK_SERVICE_DIR, 'deployment.yaml');
+
+  return new Promise((resolve) => {
+    const deleteProcess = cp.spawn('kubectl', [
+      'delete',
+      '-f', deploymentPath,
+      '--ignore-not-found'
+    ], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    deleteProcess.stdout.on('data', (data) => {
+      console.log(`[kubectl delete] ${data.toString().trim()}`);
+    });
+
+    deleteProcess.stderr.on('data', (data) => {
+      console.log(`[kubectl delete] ${data.toString().trim()}`);
+    });
+
+    deleteProcess.on('close', () => {
+      console.log('Mock embedding service deleted.');
+      resolve();
+    });
+
+    deleteProcess.on('error', () => {
+      // Ignore errors on delete
+      resolve();
+    });
+  });
+}
+
+/**
+ * Full setup: Build, load, deploy and wait for mock embedding service
+ *
+ * @param {string} clusterName - The name of the Kind cluster
+ * @returns {Promise<boolean>} - True if setup was successful
+ */
+async function setupMockEmbeddingService(clusterName = 'drasi-test') {
+  try {
+    console.log('\n========================================');
+    console.log('Setting up Mock Embedding Service');
+    console.log('========================================\n');
+
+    // Step 1: Build the Docker image
+    await buildMockEmbeddingImage();
+
+    // Step 2: Load into Kind cluster
+    await loadMockEmbeddingImageToKind(clusterName);
+
+    // Step 3: Deploy to Kubernetes
+    await deployMockEmbeddingService();
+
+    // Step 4: Wait for service to be ready
+    const ready = await waitForMockServiceReady(60000);
+
+    if (ready) {
+      console.log('\n========================================');
+      console.log('Mock Embedding Service Ready!');
+      console.log('Endpoint: http://mock-embedding-service.default.svc.cluster.local');
+      console.log('========================================\n');
+      return true;
+    } else {
+      console.error('Mock embedding service failed to become ready.');
+      return false;
+    }
+  } catch (error) {
+    console.error('Error setting up mock embedding service:', error.message);
+    return false;
+  }
+}
+
+/**
+ * Get the mock embedding service endpoint URL
+ *
+ * @returns {string}
+ */
+function getMockEmbeddingEndpoint() {
+  return `http://${MOCK_SERVICE_NAME}.${MOCK_SERVICE_NAMESPACE}.svc.cluster.local`;
+}
+
+/**
+ * Update reaction configurations to use the mock embedding service
+ *
+ * @param {Array} reactions - Array of reaction YAML objects
+ * @returns {Array} - Updated reaction objects
+ */
+function updateReactionsForMock(reactions) {
+  const mockEndpoint = getMockEmbeddingEndpoint();
+
+  reactions.forEach(reaction => {
+    if (reaction.spec?.properties) {
+      reaction.spec.properties.embeddingEndpoint = mockEndpoint;
+      reaction.spec.properties.embeddingApiKey = 'mock-api-key';
+      reaction.spec.properties.embeddingModel = 'mock-embedding-model';
+    }
+  });
+
+  return reactions;
+}
+
+module.exports = {
+  buildMockEmbeddingImage,
+  loadMockEmbeddingImageToKind,
+  deployMockEmbeddingService,
+  waitForMockServiceReady,
+  deleteMockEmbeddingService,
+  setupMockEmbeddingService,
+  getMockEmbeddingEndpoint,
+  updateReactionsForMock,
+  MOCK_SERVICE_NAME,
+  MOCK_SERVICE_NAMESPACE,
+  MOCK_IMAGE_NAME,
+  MOCK_IMAGE_TAG
+};

--- a/e2e-tests/fixtures/mock-embedding-service/Dockerfile
+++ b/e2e-tests/fixtures/mock-embedding-service/Dockerfile
@@ -1,0 +1,45 @@
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM node:20-alpine
+
+# Create app directory and set ownership to node user
+WORKDIR /app
+RUN chown node:node /app
+
+# Switch to non-root user before copying files
+USER node
+
+# Copy package files (as node user, so files are owned by node)
+COPY --chown=node:node package.json ./
+
+# Install dependencies
+RUN npm install --omit=dev
+
+# Copy application code
+COPY --chown=node:node server.js ./
+
+# Expose port
+EXPOSE 8080
+
+# Set default environment variables
+ENV PORT=8080
+ENV EMBEDDING_DIMENSIONS=3072
+
+# Health check
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
+# Start the service
+CMD ["node", "server.js"]

--- a/e2e-tests/fixtures/mock-embedding-service/README.md
+++ b/e2e-tests/fixtures/mock-embedding-service/README.md
@@ -1,0 +1,114 @@
+# Mock Embedding Service
+
+A lightweight mock service that mimics the Azure OpenAI Embeddings API for e2e testing purposes.
+
+## Purpose
+
+This service enables fork contributors to run vector store e2e tests without requiring Azure OpenAI credentials. It generates deterministic embeddings based on SHA-256 hashes of the input text, allowing the full vector store pipeline to be tested.
+
+## How It Works
+
+1. **Deterministic Embeddings**: The service generates embeddings by hashing the input text with SHA-256 and converting the hash bytes into a normalized float vector. The same text always produces the same embedding.
+
+2. **Azure OpenAI API Compatible**: Implements the Azure OpenAI embeddings endpoint format:
+   ```
+   POST /openai/deployments/{model}/embeddings?api-version={version}
+   ```
+
+3. **Automatic Deployment**: When tests detect missing Azure OpenAI credentials, they automatically:
+   - Build this Docker image
+   - Load it into the Kind cluster
+   - Deploy it as a Kubernetes service
+   - Configure reactions to use it
+
+## API Endpoints
+
+### POST /openai/deployments/{model}/embeddings
+
+Generate embeddings for input texts.
+
+**Request:**
+```json
+{
+  "input": ["text1", "text2", ...]
+}
+```
+
+**Response:**
+```json
+{
+  "object": "list",
+  "data": [
+    {"object": "embedding", "embedding": [...], "index": 0},
+    {"object": "embedding", "embedding": [...], "index": 1}
+  ],
+  "model": "{model}",
+  "usage": {"prompt_tokens": 10, "total_tokens": 10}
+}
+```
+
+### GET /health
+
+Health check endpoint.
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "service": "mock-embedding-service",
+  "dimensions": 3072,
+  "timestamp": "2025-01-01T00:00:00.000Z"
+}
+```
+
+### GET /
+
+Service information.
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `PORT` | `8080` | Port to listen on |
+| `EMBEDDING_DIMENSIONS` | `3072` | Number of dimensions for generated embeddings |
+
+## Local Development
+
+```bash
+# Install dependencies
+npm install
+
+# Run the service
+npm start
+
+# Test with curl
+curl -X POST http://localhost:8080/openai/deployments/test-model/embeddings \
+  -H "Content-Type: application/json" \
+  -H "api-key: test-key" \
+  -d '{"input": ["Hello world"]}'
+```
+
+## Building the Docker Image
+
+```bash
+docker build -t drasi-project/mock-embedding-service:latest .
+```
+
+## Limitations
+
+- **Not for semantic search**: Mock embeddings are hash-based, not semantically meaningful
+- **Testing only**: Should never be used in production
+- **Fixed dimensions**: Defaults to 3072 to match `text-embedding-3-large`
+
+## What Tests Validate with Mock
+
+- Full pipeline integration (source → query → reaction → vector store)
+- Document upsert/delete operations
+- Vector store collection creation
+- Embedding API integration
+
+## What Tests Cannot Validate with Mock
+
+- Semantic similarity or search quality
+- Actual embedding model behavior
+- Azure OpenAI rate limits or error handling

--- a/e2e-tests/fixtures/mock-embedding-service/deployment.yaml
+++ b/e2e-tests/fixtures/mock-embedding-service/deployment.yaml
@@ -1,0 +1,84 @@
+# Copyright 2025 The Drasi Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mock Embedding Service Deployment
+# Used for e2e tests when Azure OpenAI credentials are not available
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mock-embedding-service
+  namespace: default
+  labels:
+    app: mock-embedding-service
+    component: e2e-testing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mock-embedding-service
+  template:
+    metadata:
+      labels:
+        app: mock-embedding-service
+    spec:
+      containers:
+      - name: mock-embedding
+        image: drasi-project/mock-embedding-service:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: PORT
+          value: "8080"
+        - name: EMBEDDING_DIMENSIONS
+          value: "3072"
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+---
+# Service to expose the mock embedding service within the cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: mock-embedding-service
+  namespace: default
+  labels:
+    app: mock-embedding-service
+    component: e2e-testing
+spec:
+  type: ClusterIP
+  selector:
+    app: mock-embedding-service
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http

--- a/e2e-tests/fixtures/mock-embedding-service/package.json
+++ b/e2e-tests/fixtures/mock-embedding-service/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "mock-embedding-service",
+  "version": "1.0.0",
+  "description": "Mock Azure OpenAI Embedding Service for Drasi e2e tests",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"const {generateDeterministicEmbedding} = require('./server.js'); console.log('Tests passed');\""
+  },
+  "keywords": [
+    "mock",
+    "embedding",
+    "azure-openai",
+    "drasi",
+    "e2e-testing"
+  ],
+  "author": "Drasi Authors",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/e2e-tests/fixtures/mock-embedding-service/server.js
+++ b/e2e-tests/fixtures/mock-embedding-service/server.js
@@ -1,0 +1,226 @@
+/**
+ * Copyright 2025 The Drasi Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Mock Azure OpenAI Embedding Service
+ *
+ * This service mimics the Azure OpenAI embeddings API for e2e testing.
+ * It generates deterministic embeddings based on text content using SHA-256 hashing,
+ * allowing fork contributors to test the vector store pipeline without Azure credentials.
+ *
+ * API Contract (Azure OpenAI Embeddings):
+ *   POST /openai/deployments/{model}/embeddings?api-version={version}
+ *   Headers: api-key: {key}
+ *   Body: { "input": ["text1", "text2", ...] }
+ *   Response: { "data": [{ "embedding": [...], "index": 0 }, ...], "model": "...", "usage": {...} }
+ */
+
+const express = require('express');
+const crypto = require('crypto');
+
+const app = express();
+app.use(express.json({ limit: '10mb' }));
+
+// Configuration
+const PORT = parseInt(process.env.PORT || '8080');
+const DIMENSIONS = parseInt(process.env.EMBEDDING_DIMENSIONS || '3072');
+
+console.log(`Mock Embedding Service starting with ${DIMENSIONS} dimensions...`);
+
+/**
+ * Generate a deterministic embedding vector from text using SHA-256.
+ * The same text will always produce the same embedding, enabling reproducible tests.
+ *
+ * @param {string} text - Input text to embed
+ * @param {number} dimensions - Number of dimensions for the output vector
+ * @returns {number[]} - Normalized embedding vector as array of floats
+ */
+function generateDeterministicEmbedding(text, dimensions) {
+  // Create SHA-256 hash of the input text
+  const hash = crypto.createHash('sha256').update(text).digest();
+
+  const embedding = [];
+
+  // Generate deterministic floats from hash bytes
+  // We cycle through the 32-byte hash to generate all dimensions
+  for (let i = 0; i < dimensions; i++) {
+    // Use 4 bytes to create each float value for better distribution
+    const byteIndex = (i * 4) % 32;
+    const seed = (hash[byteIndex] << 24) |
+                 (hash[(byteIndex + 1) % 32] << 16) |
+                 (hash[(byteIndex + 2) % 32] << 8) |
+                 (hash[(byteIndex + 3) % 32]);
+
+    // Convert to float in range [-1, 1]
+    // Use unsigned interpretation and map to [-1, 1]
+    const unsignedSeed = seed >>> 0; // Convert to unsigned 32-bit
+    const value = (unsignedSeed / 0xFFFFFFFF) * 2 - 1;
+    embedding.push(value);
+  }
+
+  // Normalize to unit vector (important for cosine similarity)
+  const magnitude = Math.sqrt(embedding.reduce((sum, v) => sum + v * v, 0));
+  if (magnitude > 0) {
+    for (let i = 0; i < embedding.length; i++) {
+      embedding[i] = embedding[i] / magnitude;
+    }
+  }
+
+  return embedding;
+}
+
+/**
+ * Convert an array of floats to Base64-encoded binary format.
+ * This matches the format expected by the OpenAI SDK when using base64 encoding.
+ * Each float is encoded as IEEE 754 32-bit little-endian.
+ *
+ * @param {number[]} floatArray - Array of float values
+ * @returns {string} - Base64-encoded string
+ */
+function floatArrayToBase64(floatArray) {
+  // Create a buffer to hold all floats (4 bytes per float)
+  const buffer = Buffer.alloc(floatArray.length * 4);
+
+  // Write each float as a 32-bit IEEE 754 little-endian value
+  for (let i = 0; i < floatArray.length; i++) {
+    buffer.writeFloatLE(floatArray[i], i * 4);
+  }
+
+  return buffer.toString('base64');
+}
+
+/**
+ * Azure OpenAI Embeddings API endpoint
+ *
+ * Matches the Azure OpenAI API contract:
+ * POST /openai/deployments/{deployment-id}/embeddings?api-version=2023-05-15
+ *
+ * Supports both 'float' and 'base64' encoding formats.
+ * The OpenAI SDK v2.x uses base64 by default for efficiency.
+ */
+app.post('/openai/deployments/:model/embeddings', (req, res) => {
+  const startTime = Date.now();
+  const model = req.params.model;
+  const apiVersion = req.query['api-version'];
+
+  // Validate request
+  if (!req.body || !req.body.input) {
+    return res.status(400).json({
+      error: {
+        message: "Missing 'input' field in request body",
+        type: "invalid_request_error",
+        code: "invalid_request"
+      }
+    });
+  }
+
+  // Normalize input to array
+  const inputs = Array.isArray(req.body.input) ? req.body.input : [req.body.input];
+
+  if (inputs.length === 0) {
+    return res.status(400).json({
+      error: {
+        message: "Input array cannot be empty",
+        type: "invalid_request_error",
+        code: "invalid_request"
+      }
+    });
+  }
+
+  // Check encoding format (default to base64 as that's what OpenAI SDK v2.x expects)
+  const encodingFormat = req.body.encoding_format || 'base64';
+
+  // Generate embeddings for each input
+  const data = inputs.map((text, index) => {
+    const textStr = String(text);
+    const embeddingFloats = generateDeterministicEmbedding(textStr, DIMENSIONS);
+
+    // Return embedding in the requested format
+    const embedding = encodingFormat === 'base64'
+      ? floatArrayToBase64(embeddingFloats)
+      : embeddingFloats;
+
+    return {
+      object: 'embedding',
+      embedding: embedding,
+      index: index
+    };
+  });
+
+  // Calculate mock token usage (rough estimate: 1 token per 4 chars)
+  const totalTokens = inputs.reduce((sum, text) => sum + Math.ceil(String(text).length / 4), 0);
+
+  const response = {
+    object: 'list',
+    data: data,
+    model: model,
+    usage: {
+      prompt_tokens: totalTokens,
+      total_tokens: totalTokens
+    }
+  };
+
+  const duration = Date.now() - startTime;
+  console.log(`[${new Date().toISOString()}] Generated ${inputs.length} embeddings (${DIMENSIONS}D, ${encodingFormat}) in ${duration}ms for model: ${model}`);
+
+  res.json(response);
+});
+
+/**
+ * Health check endpoint
+ */
+app.get('/health', (req, res) => {
+  res.json({
+    status: 'healthy',
+    service: 'mock-embedding-service',
+    dimensions: DIMENSIONS,
+    timestamp: new Date().toISOString()
+  });
+});
+
+/**
+ * Root endpoint - service info
+ */
+app.get('/', (req, res) => {
+  res.json({
+    service: 'Mock Azure OpenAI Embedding Service',
+    description: 'Generates deterministic embeddings for e2e testing',
+    dimensions: DIMENSIONS,
+    endpoints: {
+      embeddings: 'POST /openai/deployments/{model}/embeddings',
+      health: 'GET /health'
+    }
+  });
+});
+
+// Error handling middleware
+app.use((err, req, res, next) => {
+  console.error(`[${new Date().toISOString()}] Error:`, err.message);
+  res.status(500).json({
+    error: {
+      message: 'Internal server error',
+      type: 'server_error',
+      code: 'internal_error'
+    }
+  });
+});
+
+// Start server
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`Mock Embedding Service running on port ${PORT}`);
+  console.log(`Embedding dimensions: ${DIMENSIONS}`);
+  console.log(`Health check: http://localhost:${PORT}/health`);
+});

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -1688,41 +1688,6 @@
       "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.14",
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "license": "MIT",
-      "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
@@ -5049,12 +5014,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "license": "MIT"
     },
     "node_modules/psl": {


### PR DESCRIPTION
# Description

Enable fork contributors to run vector store e2e tests by automatically deploying a mock embedding service when Azure OpenAI credentials are unavailable.

## Problem

Previously, vector store e2e tests (scenarios 07 and 08) were completely skipped for fork-based pull requests because GitHub doesn't expose secrets to
workflows triggered by forks. This meant fork contributors couldn't test the vector store reaction pipeline at all.

## Solution

Implemented a lightweight mock embedding service that:

- **Implements Azure OpenAI API** - Compatible with Semantic Kernel's `AddAzureOpenAIEmbeddingGenerator()`
- **Generates deterministic embeddings** - Uses SHA-256 hashing to produce consistent, reproducible 3072-dimensional vectors
- **Deploys automatically** - When tests detect missing credentials, the mock is built, loaded into Kind, and deployed
- **Requires no test logic changes** - All existing test assertions pass with mock embeddings

### What gets tested with mock embeddings

| Aspect | Tested? |
|--------|---------|
| Full pipeline (source → query → reaction → vector store) | ✅ |
| Document upsert/update/delete operations | ✅ |
| Vector store collection creation | ✅ |
| Embedding API integration | ✅ |
| Qdrant HTTP API operations | ✅ |
| Semantic similarity/search quality | ❌ (tested with real credentials) |

### Files changed

**New files:**
- `e2e-tests/fixtures/mock-embedding-service/server.js` - Express server with Azure OpenAI API
- `e2e-tests/fixtures/mock-embedding-service/package.json` - Dependencies
- `e2e-tests/fixtures/mock-embedding-service/Dockerfile` - Container image
- `e2e-tests/fixtures/mock-embedding-service/deployment.yaml` - K8s manifests
- `e2e-tests/fixtures/mock-embedding-service/README.md` - Documentation
- `e2e-tests/fixtures/deploy-mock-embedding.js` - Deployment helper

**Modified files:**
- `e2e-tests/07-sync-inmemory-vectorstore-scenario/inmemory-vectorstore.test.js`
- `e2e-tests/08-sync-qdrant-vectorstore-scenario/qdrant-vectorstore.test.js`
- `e2e-tests/README.md`

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue
link optional).

Fixes: N/A (test infrastructure improvement)