### PR TITLE
Fix broken URLs in quick-test cleanup scripts

### DIFF
--- a/dev-tools/testing/quick-test-environment/cleanup-quick-test-environment.ps1
+++ b/dev-tools/testing/quick-test-environment/cleanup-quick-test-environment.ps1
@@ -8,9 +8,9 @@ if (-not $namespace) {
 
 
 drasi namespace set $namespace
-kubectl delete -f https://raw.githubusercontent.com/main/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-postgres.yaml -n default
+kubectl delete -f https://raw.githubusercontent.com/drasi-project/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-postgres.yaml -n default
 
-drasi delete -f https://raw.githubusercontent.com/main/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-reaction.yaml
-drasi delete -f https://raw.githubusercontent.com/main/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-query.yaml
-drasi delete -f https://raw.githubusercontent.com/main/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-source.yaml
+drasi delete -f https://raw.githubusercontent.com/drasi-project/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-reaction.yaml
+drasi delete -f https://raw.githubusercontent.com/drasi-project/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-query.yaml
+drasi delete -f https://raw.githubusercontent.com/drasi-project/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-source.yaml
 

--- a/dev-tools/testing/quick-test-environment/cleanup-quick-test-environment.sh
+++ b/dev-tools/testing/quick-test-environment/cleanup-quick-test-environment.sh
@@ -6,9 +6,9 @@ fi
 
 
 drasi namespace set $namespace
-kubectl delete -f https://raw.githubusercontent.com/main/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-postgres.yaml -n default
+kubectl delete -f https://raw.githubusercontent.com/drasi-project/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-postgres.yaml -n default
 
-drasi delete -f https://raw.githubusercontent.com/main/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-reaction.yaml
-drasi delete -f https://raw.githubusercontent.com/main/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-query.yaml
-drasi delete -f https://raw.githubusercontent.com/main/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-source.yaml
+drasi delete -f https://raw.githubusercontent.com/drasi-project/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-reaction.yaml
+drasi delete -f https://raw.githubusercontent.com/drasi-project/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-query.yaml
+drasi delete -f https://raw.githubusercontent.com/drasi-project/drasi-platform/main/dev-tools/testing/quick-test-environment/resources/quick-test-source.yaml
 


### PR DESCRIPTION
# Description

The quick-test cleanup script - which is supposed to be executed after a failed quick-test - is referencing some URLs (same ones as the original quick-test presumably), that return 404. Somehow there was a rogue second "main" in the URLs instead of a "drasi-project".

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->
