### PR TITLE
fix: use Arrays.equals for byte array comparison in OffsetBackingStore

### DIFF
--- a/sources/relational/debezium-reactivator/src/main/java/io/drasi/OffsetBackingStore.java
+++ b/sources/relational/debezium-reactivator/src/main/java/io/drasi/OffsetBackingStore.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -56,7 +57,7 @@ public class OffsetBackingStore extends MemoryOffsetBackingStore {
         var instanceId = System.getenv("INSTANCE_ID").getBytes();
         var resp = stateStore.get("instance_id");
 
-        if (resp == null || !resp.equals(instanceId)) {
+        if (resp == null || !Arrays.equals(resp, instanceId)) {
             log.info("Instance ID mismatch. Clearing offset store.");
             stateStore.delete("offset");
             stateStore.put("instance_id", instanceId);


### PR DESCRIPTION
What's happening                                                                                                                                                                                                                                                                                                                Every time the relational source reactivator pod restarted — whether from a liveness probe kill, OOM eviction, rolling update, or anything else — it was      
  silently wiping the Debezium WAL offset it had carefully saved to the Dapr state store, then starting the change stream from scratch.

  The root cause is a Java gotcha in OffsetBackingStore.start(). The code was comparing two byte[] arrays with .equals(), which in Java compares object
  references, not array contents. So even when the INSTANCE_ID stored in the state store was byte-for-byte identical to the current environment variable, the   
  comparison always returned false, the log printed "Instance ID mismatch" (even though there was no mismatch), and the offset got deleted.

  // always false — two distinct byte[] objects are never reference-equal
  if (resp == null || !resp.equals(instanceId)) {

  The offset backing store exists for one reason: so the connector can resume from its exact last committed LSN after a restart instead of replaying from the   
  slot's position. With this bug, that resume mechanism has never worked. Every restart was effectively a cold start, causing duplicate CDC events for the      
  in-flight window since the last confirmed flush.

  The fix

  Replace .equals() with Arrays.equals(), which compares contents:

  if (resp == null || !Arrays.equals(resp, instanceId)) {

  That's it. The INSTANCE_ID guard now works as intended: same connector restarting → keep the offset, resume cleanly. New deployment → clear the offset, start 
  fresh.

  Why this matters

  This affects any Drasi deployment using a PostgreSQL, MySQL, or SQL Server source. The duplicate events weren't noisy — there were no errors, no crashes, just
   the occasional phantom re-appearance of already-processed changes after every pod lifecycle event. In a production cluster with routine restarts, that means 
  continuous silent drift in continuous query results.

  Testing

  - Deploy a relational source against a live database with active writes
  - Confirm changes are flowing
  - Delete the reactivator pod: kubectl delete pod -l app=<source-id>-reactivator -n drasi-system
  - After restart, verify the log no longer prints "Instance ID mismatch" and that no events are duplicated