### PR TITLE
  Fix drasi wait reporting false readiness on redeployed resources (#…

### DIFF
--- a/control-planes/kubernetes_provider/src/controller/reconciler.rs
+++ b/control-planes/kubernetes_provider/src/controller/reconciler.rs
@@ -349,8 +349,24 @@ impl ResourceReconciler {
                     log::info!("Updating deployment {}", name);
                     let pp = PatchParams::default();
                     let pat = Patch::Merge(&dep);
-                    self.deployment_api.patch(&name, &pp, &pat).await?;
-                    self.status = ReconcileStatus::Offline("Updating deployment".to_string());
+                    let update_result = self.deployment_api.patch(&name, &pp, &pat).await?;
+
+                    // Check if K8s is rolling out new pods by comparing generation numbers.The API server increments generation on spec changes (e.g., pod template),
+                    // but NOT on metadata-only changes (e.g., annotation hash update).If generation > observedGeneration, a rollout is in progress and we must
+                    // wait for the monitor to trigger re-reconciliation when new pods come up.Otherwise, the patch didn't affect pods and current status is valid.
+                    let generation = update_result.metadata.generation.unwrap_or(0);
+                    let observed = update_result
+                        .status
+                        .as_ref()
+                        .and_then(|s| s.observed_generation)
+                        .unwrap_or(0);
+
+                    if generation > observed {
+                        self.status =
+                            ReconcileStatus::Offline("Updating deployment".to_string());
+                    } else {
+                        self.update_deployment_status(&update_result).await;
+                    }
                 } else {
                     self.update_deployment_status(&current).await;
                 }


### PR DESCRIPTION
<p><strong>Description</strong></p>
<p>Fixes <code>drasi wait</code> incorrectly reporting a resource as ready when a resource (QueryContainer, Source, or Reaction) is deleted and re-created with the same name, or re-applied with updated config. The command returns immediately with a false positive before the new pods are actually running.</p>
<p><strong>Root Cause Analysis</strong></p>
<p>Traced the full call chain across 4 layers to isolate the bug:</p>

Layer | File | Role
-- | -- | --
CLI command | cli/cmd/wait.go | Parses args, delegates to ReadyWait()
CLI SDK | cli/sdk/api_client.go:193 | Sends GET /v1/{resource}/{id}/ready-wait
Management API | mgmt_api/src/api/v1/query_containers.rs:146 | Validates timeout, calls service.wait_for_ready()
Domain service | mgmt_api/src/domain/resource_services/standard/mod.rs:201 | Polls actor getStatus every 1s
Actor (k8s provider) | kubernetes_provider/src/actors/mod.rs:79 | configure() → load_controllers() → reconcile_internal()
Reconciler (BUG HERE) | kubernetes_provider/src/controller/reconciler.rs:346 | reconcile_deployment() reads stale pod status


<p><strong>Components verified (not affected):</strong></p>
<ul>
<li><code>controller/mod.rs</code>: <code>ResourceController::start()</code> initializes status as <code>Unknown</code> via <code>watch::channel</code>. Status only published after <code>reconcile()</code> completes. No change needed.</li>
<li><code>actors/mod.rs</code>: <code>configure()</code> calls <code>reconcile_internal()</code> (non-blocking). <code>on_activate()</code> calls <code>reconcile_internal_async()</code> (blocking). Both paths go through the same <code>reconcile_deployment()</code>. Fix applies correctly to both.</li>
<li><code>querycontainer_actor.rs</code> / <code>source_actor.rs</code> / <code>reaction_actor.rs</code>: All share the same <code>ResourceActor</code> and <code>ResourceReconciler</code>. Fix applies to all resource types.</li>
<li><code>monitor/mod.rs</code>: Watches pod events, sends reconcile command to actors. This is the mechanism that will trigger the status update after the fix sets <code>Offline</code>. No change needed.</li>
<li><code>mgmt_api</code> domain services: Both <code>StandardResourceDomainServiceImpl</code> and <code>ExtensibleResourceDomainServiceImpl</code> have identical <code>wait_for_ready()</code> implementations that poll <code>getStatus</code>. Both benefit from this fix without any changes.</li>
<li>CLI (<code>wait.go</code>, <code>api_client.go</code>): Pure HTTP delegation. No changes needed.</li>
</ul>
<hr>
<p><strong>Type of change</strong></p>
<ul>
<li>This pull request fixes a bug in Drasi and has an approved issue (issue link required).</li>
</ul>
<p>Fixes: #273</p>
<p><strong>Test plan</strong></p>
<ul>
<li>[ ] Deploy a QueryContainer, verify <code>drasi wait</code> works correctly on first creation</li>
<li>[ ] Re-apply the same QueryContainer with updated config, verify <code>drasi wait</code> blocks until new pods are ready</li>
<li>[ ] Delete a QueryContainer and recreate with the same name, verify <code>drasi wait</code> blocks until new pods are ready</li>
<li>[ ] Re-apply with identical config (no-op), verify <code>drasi wait</code> returns immediately</li>
<li>[ ] Verify Sources and Reactions also behave correctly on re-deploy</li>
</ul></body></html>