### PR TITLE
ci: add trivy container vulnerability scanning pre-merge

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -338,6 +338,16 @@ jobs:
           cd ${{ matrix.component.path }}
           BUILD_CONFIG=${{ matrix.variant.build_config }} DOCKERX_OPTS="--output type=docker,dest=${{ github.workspace }}/${{ matrix.component.name }}-${{ matrix.variant.name }}.tar --cache-to type=local,dest=/tmp/.buildx-cache,mode=max --cache-from type=local,src=/tmp/.buildx-cache" make
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          input: ${{ github.workspace }}/${{ matrix.component.name }}-${{ matrix.variant.name }}.tar
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
       - name: Upload artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:


### PR DESCRIPTION
# Description

The `build-test` workflow currently builds 30+ microservices for E2E testing without running a dedicated container vulnerability scan. High/Critical CVEs inherited from base images could merge undetected.

This PR adds local `aquasecurity/trivy-action` scanning directly within the `build-images` matrix. It scans the generated `.tar` artifacts for `CRITICAL` or `HIGH` vulnerabilities across all variants and fails the action if any are found (where a fix is available). 

Scanning the local tarball avoids registry push overhead, securing the build phase with negligible latency cost.

## Type of change

- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--
Please update the following to link the associated issue. This is required for some kinds of changes (see above).
-->

Fixes: N/A (Infrastructure Proactive Patch)
