### PR TITLE
 Fix: Reset Redis consumer group position after re-bootstrap on pod restart

### DIFF
--- a/query-container/query-host/src/change_stream/redis_change_stream.rs
+++ b/query-container/query-host/src/change_stream/redis_change_stream.rs
@@ -41,6 +41,7 @@ impl RedisChangeStream {
         buffer_size: usize,
         fetch_batch_size: usize,
         start_timestamp: u128,
+        reset_position: bool,
     ) -> Result<Self, ChangeStreamError> {
         let client = redis::Client::open(url)?;
         let mut connection = client.get_async_connection().await?;
@@ -53,7 +54,30 @@ impl RedisChangeStream {
         {
             Ok(res) => log::info!("Created consumer group: {:?}", res),
             Err(err) => match err.kind() {
-                redis::ErrorKind::ExtensionError => log::info!("Consumer group already exists"),
+                redis::ErrorKind::ExtensionError => {
+                    if reset_position {
+                        log::info!(
+                            "Consumer group already exists, resetting position to {} after re-bootstrap",
+                            starting_position
+                        );
+                        match connection
+                            .xgroup_setid::<&str, &str, &str, String>(
+                                topic,
+                                group_id,
+                                &starting_position,
+                            )
+                            .await
+                        {
+                            Ok(_) => log::info!("Consumer group position reset successfully"),
+                            Err(err) => {
+                                log::error!("Error resetting consumer group position: {:?}", err);
+                                return Err(ChangeStreamError::from(err));
+                            }
+                        }
+                    } else {
+                        log::info!("Consumer group already exists, resuming from last position");
+                    }
+                }
                 _ => log::error!("Consumer group create error: {:?} {:?}", err, err.kind()),
             },
         };

--- a/query-container/query-host/src/change_stream/tests.rs
+++ b/query-container/query-host/src/change_stream/tests.rs
@@ -50,7 +50,7 @@ async fn serves_messages_sequentially() {
         .unwrap();
 
     let subject =
-        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp)
+        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp, false)
             .await
             .unwrap();
 
@@ -105,7 +105,7 @@ async fn buffers_messages() {
         .unwrap();
 
     let subject =
-        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp)
+        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp, false)
             .await
             .unwrap();
 
@@ -160,7 +160,7 @@ async fn recovers_unack_messages() {
         .unwrap();
 
     let subject =
-        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp)
+        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp, false)
             .await
             .unwrap();
 
@@ -186,7 +186,7 @@ async fn recovers_unack_messages() {
     drop(subject);
 
     let subject =
-        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp)
+        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp, false)
             .await
             .unwrap();
 
@@ -214,7 +214,7 @@ async fn waits_for_new_messages() {
         .unwrap();
 
     let subject =
-        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp)
+        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp, false)
             .await
             .unwrap();
 
@@ -246,7 +246,7 @@ async fn stops_buffering_on_drop() {
         .unwrap();
 
     let subject =
-        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp)
+        RedisChangeStream::new(&url, &query_container_id, &query_id, 5, 3, start_timestamp, false)
             .await
             .unwrap();
 

--- a/query-container/query-host/src/query_worker.rs
+++ b/query-container/query-host/src/query_worker.rs
@@ -229,6 +229,11 @@ impl QueryWorker {
                 init_seq.sequence
             );
 
+            let did_bootstrap = matches!(
+                lifecycle.get_state(),
+                QueryState::Configured | QueryState::Bootstrapping
+            );
+
             match lifecycle.get_state() {
                 QueryState::Configured | QueryState::Bootstrapping => {
                     lifecycle.change_state(QueryState::Bootstrapping);
@@ -267,6 +272,7 @@ impl QueryWorker {
                 stream_config.buffer_size,
                 stream_config.fetch_batch_size,
                 start_timestamp,
+                did_bootstrap,
             )
             .await
             {


### PR DESCRIPTION
## The Bug

When a query pod restarts with volatile storage (the default), it re-bootstraps correctly, clears indexes and reloads fresh data from the source. But the Redis consumer group still points to its old position from before the crash.

This means unacked messages get re-processed on top of fresh data. Since `element_index.set_element()` just overwrites, stale messages corrupt the newly bootstrapped index.

**Example:**
```
100 orders @ $10 = $1000
Insert 5 orders @ $20 (2 messages unacked)
Pod crashes and restarts
Expected: $1100
Actual: $1200 (the 2 pending messages re-processed as new inserts)
```

This happens on every pod restart, OOM kills, rolling updates, node preemptions. No errors logged, aggregations just wrong forever.

## The Fix

Added a `reset_position` flag to `RedisChangeStream::new()`. When the consumer group already exists and we just re-bootstrapped, reset its position with `XGROUP SETID`:

```rust
if reset_position {
    log::info!("Resetting consumer group position to {}", starting_position);
    connection.xgroup_setid(topic, group_id, &starting_position).await?;
}
```

I pass `did_bootstrap` from `query_worker.rs` as the reset flag. This way:
- TransientError recovery: no reset, re-process pending messages ✓
- Volatile restart: reset position, discard stale messages ✓


## Tested

Validated all scenarios manually. After fix, volatile restarts correctly log the position reset and aggregations stay correct—no phantom additions.

---

This makes the default config safe for production. Happy to iterate based on feedback!