### PR TITLE
fix: change URL typo of getting started section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ This streamlined setup ensures drivers are promptly informed, optimizing the del
 
 ## Getting Started
 
-Follow the [Getting Started tutorial](https://drasi.io/getting-started/) and try out Drasi. The tutorial will lead you through:
+Follow the [Getting Started tutorial](https://drasi.io/drasi-server/getting-started/) and try out Drasi. The tutorial will lead you through:
 
 1. Applying a Source representing the data source whose changes you want to observe.
 2. Creating Continuous Queries to define the data to observe, conditions to assess changes, and the structure of the output.


### PR DESCRIPTION
# Description

The README had a typo in URL of "getting started" leading to a 404 error, thus I fixed the link to actual getting started page.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

