### PR TITLE
Add WaitForQueryReadyAsync to native IManagementClient

### DIFF
--- a/reactions/sdk/dotnet/Drasi.Reaction.SDK.Tests/Drasi.Reaction.SDK.Tests.csproj
+++ b/reactions/sdk/dotnet/Drasi.Reaction.SDK.Tests/Drasi.Reaction.SDK.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/reactions/sdk/dotnet/Drasi.Reaction.SDK.Tests/ManagementClientTests.cs
+++ b/reactions/sdk/dotnet/Drasi.Reaction.SDK.Tests/ManagementClientTests.cs
@@ -1,0 +1,192 @@
+using System.Net;
+using Drasi.Reaction.SDK.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Moq.Protected;
+
+namespace Drasi.Reactions.SDK.Tests;
+public class ManagementClientTests
+{
+    private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
+    private readonly Mock<ILogger<ManagementClient>> _mockLogger;
+    private readonly Mock<IConfiguration> _mockConfiguration;
+    private readonly ManagementClient _client;
+    private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+    private readonly HttpClient _httpClient;
+
+    public ManagementClientTests()
+    {
+        _mockHttpClientFactory = new Mock<IHttpClientFactory>();
+        _mockLogger = new Mock<ILogger<ManagementClient>>();
+        _mockConfiguration = new Mock<IConfiguration>();
+
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_mockHttpMessageHandler.Object);
+
+        _mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(_httpClient);
+        _mockConfiguration.Setup(c => c[ManagementClient.DrasiManagementApiBaseUrlConfigKey])
+            .Returns(ManagementClient.DefaultDrasiManagementApiBaseUrl);
+
+        _client = new ManagementClient(
+            _mockHttpClientFactory.Object,
+            _mockConfiguration.Object,
+            _mockLogger.Object);
+    }
+
+    // null queryId throws ArgumentNullException
+    [Fact]
+    public async Task WaitForQueryReadyAsync_NullQueryId_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _client.WaitForQueryReadyAsync(null!));
+    }
+
+    // whitespace queryId throws ArgumentNullException
+    [Fact]
+    public async Task WaitForQueryReadyAsync_EmptyQueryId_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _client.WaitForQueryReadyAsync(" "));
+    }
+
+    // HTTP 200 returns true
+    [Fact]
+    public async Task WaitForQueryReadyAsync_SuccessfulResponse_ReturnsTrue()
+    {
+        var queryId = "testQuery";
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("")
+            });
+
+        var result = await _client.WaitForQueryReadyAsync(queryId);
+        
+        Assert.True(result);
+    }
+
+    // HTTP 503 returns false
+    [Fact]
+    public async Task WaitForQueryReadyAsync_ServiceUnavailable_ReturnsFalse()
+    {
+        var queryId = "testQuery";
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.ServiceUnavailable,
+                Content = new StringContent("")
+            });
+
+        var result = await _client.WaitForQueryReadyAsync(queryId);
+
+        Assert.False(result);
+    }
+
+    // HTTP 404 returns false
+    [Fact]
+    public async Task WaitForQueryReadyAsync_NotFound_ReturnsFalse()
+    {
+        var queryId = "testQuery";
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.NotFound,
+                Content = new StringContent("")
+            });
+
+        var result = await _client.WaitForQueryReadyAsync(queryId);
+
+        Assert.False(result);
+    }
+
+    // other error codes return false
+    [Fact]
+    public async Task WaitForQueryReadyAsync_OtherErrorStatusCode_ReturnsFalse()
+    {
+        var queryId = "testQuery";
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.InternalServerError,
+                Content = new StringContent("Error")
+            });
+
+        var result = await _client.WaitForQueryReadyAsync(queryId);
+
+        Assert.False(result);
+    }
+
+    // OperationCanceledException returns false
+    [Fact]
+    public async Task WaitForQueryReadyAsync_OperationCanceled_ReturnsFalse()
+    {
+        var queryId = "testQuery";
+        var cts = new CancellationTokenSource();
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        
+        cts.Cancel();
+        var result = await _client.WaitForQueryReadyAsync(queryId, waitSeconds: 5, cancellationToken: cts.Token);
+        
+        Assert.False(result);
+    }
+
+    // HttpRequestException returns false
+    [Fact]
+    public async Task WaitForQueryReadyAsync_HttpRequestException_ReturnsFalse()
+    {
+        var queryId = "testQuery";
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ThrowsAsync(new HttpRequestException("Request failed"));
+
+        var result = await _client.WaitForQueryReadyAsync(queryId);
+
+        Assert.False(result);
+    }
+
+    // unexpected exception is re-thrown
+    [Fact]
+    public async Task WaitForQueryReadyAsync_GenericException_Throws()
+    {
+        var queryId = "testQuery";
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        await Assert.ThrowsAsync<Exception>(() => _client.WaitForQueryReadyAsync(queryId));
+    }
+}

--- a/reactions/sdk/dotnet/Drasi.Reaction.SDK/Drasi.Reaction.SDK.csproj
+++ b/reactions/sdk/dotnet/Drasi.Reaction.SDK/Drasi.Reaction.SDK.csproj
@@ -25,6 +25,7 @@
     <None Include="drasi.png" Pack="true" PackagePath="\"/>
     <PackageReference Include="Dapr.AspNetCore" Version="1.14.0" />
     <PackageReference Include="Dapr.Client" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="YamlDotNet" Version="16.1.3" />
   </ItemGroup>
 

--- a/reactions/sdk/dotnet/Drasi.Reaction.SDK/ReactionBuilder.cs
+++ b/reactions/sdk/dotnet/Drasi.Reaction.SDK/ReactionBuilder.cs
@@ -38,6 +38,7 @@ namespace Drasi.Reaction.SDK
         {
             _webappBuilder = WebApplication.CreateBuilder();
             _webappBuilder.Services.AddDaprClient();
+            _webappBuilder.Services.AddHttpClient();
             _webappBuilder.Services.AddControllers();
             _webappBuilder.Services.AddSingleton<IQueryConfigService, QueryConfigService>();
             _webappBuilder.Services.AddSingleton<IConfigDeserializer, NullConfigDeserializer>();

--- a/reactions/sdk/dotnet/Drasi.Reaction.SDK/Services/IManagementClient.cs
+++ b/reactions/sdk/dotnet/Drasi.Reaction.SDK/Services/IManagementClient.cs
@@ -4,5 +4,6 @@ namespace Drasi.Reaction.SDK.Services
     public interface IManagementClient
     {
         Task<string> GetQueryContainerId(string queryId);
+        Task<bool> WaitForQueryReadyAsync(string queryId, int waitSeconds, CancellationToken cancellationToken);
     }
 }

--- a/reactions/sdk/dotnet/Drasi.Reaction.SDK/Services/ManagementClient.cs
+++ b/reactions/sdk/dotnet/Drasi.Reaction.SDK/Services/ManagementClient.cs
@@ -27,13 +27,15 @@ namespace Drasi.Reaction.SDK.Services
 
         public async Task<string> GetQueryContainerId(string queryId)
         {
-            var httpClient = _httpClientFactory.CreateClient();
-            httpClient.BaseAddress = new Uri(_managementApiBaseUrl);
-            var resp = await httpClient.GetAsync($"/v1/continuousQueries/{queryId}");
-            resp.EnsureSuccessStatusCode();
-            var body = await resp.Content.ReadFromJsonAsync<JsonDocument>() ?? throw new Exception("Failed to parse response body");
-            var spec = body.RootElement.GetProperty("spec");
-            return spec.GetProperty("container").GetString() ?? throw new Exception("Failed to parse response body");
+            using (var httpClient = _httpClientFactory.CreateClient())
+            {
+                httpClient.BaseAddress = new Uri(_managementApiBaseUrl);
+                var resp = await httpClient.GetAsync($"/v1/continuousQueries/{queryId}");
+                resp.EnsureSuccessStatusCode();
+                var body = await resp.Content.ReadFromJsonAsync<JsonDocument>() ?? throw new Exception("Failed to parse response body");
+                var spec = body.RootElement.GetProperty("spec");
+                return spec.GetProperty("container").GetString() ?? throw new Exception("Failed to parse response body");
+            }
         }
 
         public async Task<bool> WaitForQueryReadyAsync(string queryId, int waitSeconds = DefaultApiTimeoutSeconds, CancellationToken cancellationToken = default)
@@ -44,55 +46,57 @@ namespace Drasi.Reaction.SDK.Services
                 throw new ArgumentNullException(nameof(queryId));
             }
 
-            var httpClient = _httpClientFactory.CreateClient();
-            httpClient.Timeout = TimeSpan.FromSeconds(waitSeconds + ClientSideExtraTimeoutSeconds);
-
-            var requestUri = $"{_managementApiBaseUrl}/v1/continuousQueries/{queryId}/ready-wait?timeout={waitSeconds}";
-            _logger.LogInformation("Waiting for {Timeout} seconds for query {QueryId} to be ready...", waitSeconds, queryId);
-
-            try
+            using (var httpClient = _httpClientFactory.CreateClient())
             {
-                using var response = await httpClient.GetAsync(requestUri, cancellationToken);
+                httpClient.Timeout = TimeSpan.FromSeconds(waitSeconds + ClientSideExtraTimeoutSeconds);
 
-                if (response.IsSuccessStatusCode)
+                var requestUri = $"{_managementApiBaseUrl}/v1/continuousQueries/{queryId}/ready-wait?timeout={waitSeconds}";
+                _logger.LogInformation("Waiting for {Timeout} seconds for query {QueryId} to be ready...", waitSeconds, queryId);
+
+                try
                 {
-                    _logger.LogDebug("Query {QueryId} is ready.", queryId);
-                    return true;
+                    using var response = await httpClient.GetAsync(requestUri, cancellationToken);
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        _logger.LogDebug("Query {QueryId} is ready.", queryId);
+                        return true;
+                    }
+                    else if (response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
+                    {
+                        _logger.LogWarning("Query {QueryId} did not become ready within {WaitSeconds}s. Status: {StatusCode}",
+                            queryId, waitSeconds, response.StatusCode);
+                        return false;
+                    }
+                    else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                    {
+                        _logger.LogError("Query {QueryId} not found while waiting for readiness. Status: {StatusCode}",
+                            queryId, response.StatusCode);
+                        return false;
+                    }
+                    else
+                    {
+                        var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                        _logger.LogError("Failed to get readiness status for query {QueryId}. Status: {StatusCode}, Reason: {ReasonPhrase}, Content: {ResponseContent}",
+                            queryId, response.StatusCode, response.ReasonPhrase, responseContent);
+                        return false;
+                    }
                 }
-                else if (response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
+                catch (OperationCanceledException)
                 {
-                    _logger.LogWarning("Query {QueryId} did not become ready within {WaitSeconds}s. Status: {StatusCode}",
-                        queryId, waitSeconds, response.StatusCode);
+                    _logger.LogWarning("Operation to wait for query {QueryId} readiness was canceled.", queryId);
                     return false;
                 }
-                else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                catch (HttpRequestException ex)
                 {
-                    _logger.LogError("Query {QueryId} not found while waiting for readiness. Status: {StatusCode}",
-                        queryId, response.StatusCode);
+                    _logger.LogError(ex, "HTTP request failed while waiting for query {QueryId} readiness at {RequestUri}.", queryId, requestUri);
                     return false;
                 }
-                else
+                catch (Exception ex)
                 {
-                    var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-                    _logger.LogError("Failed to get readiness status for query {QueryId}. Status: {StatusCode}, Reason: {ReasonPhrase}, Content: {ResponseContent}",
-                        queryId, response.StatusCode, response.ReasonPhrase, responseContent);
-                    return false;
+                    _logger.LogError(ex, "An unexpected error occurred while waiting for query {QueryId} to be ready.", queryId);
+                    throw;
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogWarning("Operation to wait for query {QueryId} readiness was canceled.", queryId);
-                return false;
-            }
-            catch (HttpRequestException ex)
-            {
-                _logger.LogError(ex, "HTTP request failed while waiting for query {QueryId} readiness at {RequestUri}.", queryId, requestUri);
-                return false;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "An unexpected error occurred while waiting for query {QueryId} to be ready.", queryId);
-                throw;
             }
         }
     }

--- a/reactions/sdk/dotnet/Drasi.Reaction.SDK/Services/ManagementClient.cs
+++ b/reactions/sdk/dotnet/Drasi.Reaction.SDK/Services/ManagementClient.cs
@@ -1,29 +1,99 @@
 ﻿using System;
 using System.Text.Json;
 using System.Net.Http.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Drasi.Reaction.SDK.Services
 {
     public class ManagementClient : IManagementClient
     {
-        private readonly string _managementApiUrl = "http://drasi-api:8080";
-        private readonly HttpClient _httpClient;
+        private readonly string _managementApiBaseUrl;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<ManagementClient> _logger;
 
-        public ManagementClient()
+        public const string DrasiManagementApiBaseUrlConfigKey = "DrasiManagementApiBaseUrl";
+        public const string DefaultDrasiManagementApiBaseUrl = "http://drasi-api:8080";
+
+        public const int DefaultApiTimeoutSeconds = 120;
+        public const int ClientSideExtraTimeoutSeconds = 3;
+
+        public ManagementClient(IHttpClientFactory httpClientFactory, IConfiguration configuration, ILogger<ManagementClient> logger)
         {
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri(_managementApiUrl)
-            };
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _managementApiBaseUrl = configuration?[DrasiManagementApiBaseUrlConfigKey] ?? DefaultDrasiManagementApiBaseUrl;
         }
 
         public async Task<string> GetQueryContainerId(string queryId)
         {
-            var resp = await _httpClient.GetAsync($"/v1/continuousQueries/{queryId}");
+            var httpClient = _httpClientFactory.CreateClient();
+            httpClient.BaseAddress = new Uri(_managementApiBaseUrl);
+            var resp = await httpClient.GetAsync($"/v1/continuousQueries/{queryId}");
             resp.EnsureSuccessStatusCode();
             var body = await resp.Content.ReadFromJsonAsync<JsonDocument>() ?? throw new Exception("Failed to parse response body");
             var spec = body.RootElement.GetProperty("spec");
             return spec.GetProperty("container").GetString() ?? throw new Exception("Failed to parse response body");
+        }
+
+        public async Task<bool> WaitForQueryReadyAsync(string queryId, int waitSeconds = DefaultApiTimeoutSeconds, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(queryId))
+            {
+                _logger.LogError("Query ID cannot be null or whitespace.");
+                throw new ArgumentNullException(nameof(queryId));
+            }
+
+            var httpClient = _httpClientFactory.CreateClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(waitSeconds + ClientSideExtraTimeoutSeconds);
+
+            var requestUri = $"{_managementApiBaseUrl}/v1/continuousQueries/{queryId}/ready-wait?timeout={waitSeconds}";
+            _logger.LogInformation("Waiting for {Timeout} seconds for query {QueryId} to be ready...", waitSeconds, queryId);
+
+            try
+            {
+                using var response = await httpClient.GetAsync(requestUri, cancellationToken);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    _logger.LogDebug("Query {QueryId} is ready.", queryId);
+                    return true;
+                }
+                else if (response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
+                {
+                    _logger.LogWarning("Query {QueryId} did not become ready within {WaitSeconds}s. Status: {StatusCode}",
+                        queryId, waitSeconds, response.StatusCode);
+                    return false;
+                }
+                else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    _logger.LogError("Query {QueryId} not found while waiting for readiness. Status: {StatusCode}",
+                        queryId, response.StatusCode);
+                    return false;
+                }
+                else
+                {
+                    var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+                    _logger.LogError("Failed to get readiness status for query {QueryId}. Status: {StatusCode}, Reason: {ReasonPhrase}, Content: {ResponseContent}",
+                        queryId, response.StatusCode, response.ReasonPhrase, responseContent);
+                    return false;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogWarning("Operation to wait for query {QueryId} readiness was canceled.", queryId);
+                return false;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "HTTP request failed while waiting for query {QueryId} readiness at {RequestUri}.", queryId, requestUri);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An unexpected error occurred while waiting for query {QueryId} to be ready.", queryId);
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

Adds `WaitForQueryReadyAsync` directly to the existing `IManagementClient` interface. It combines workarounds from `sync-vectorstore` and `sync-statestore`'s `ExtendedManagementClient` into the core client.

**Changes:**
* Added `WaitForQueryReadyAsync` to `IManagementClient`.
* Updated `ManagementClient` to use `IHttpClientFactory`. This also means an update to `ManagementClient`'s constructor.
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now. 

-->

- [ ] This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- [x] This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- [ ] This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #403
