### PR TITLE
feat(cli): add pre-flight manifest validation to drasi apply

### DIFF
--- a/cli/cmd/apply.go
+++ b/cli/cmd/apply.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"drasi.io/cli/api"
 	"drasi.io/cli/output"
@@ -27,6 +28,7 @@ import (
 type applyCmdOptions struct {
 	platformClientFactory func(namespace string) (sdk.PlatformClient, error)
 	outputFactory         func() output.TaskOutput
+	openapiSpec           []byte
 }
 
 // NewApplyCommand creates the apply command with optional dependency injection
@@ -62,6 +64,19 @@ Usage examples:
 
 			if len(*manifests) == 0 {
 				return errors.New("no manifests found. Did you forget to specify the '-f' flag")
+			}
+			validationErrs, err := ValidateManifests(*manifests, opt.openapiSpec)
+
+			if err != nil {
+				return fmt.Errorf("validation setup failed: %w", err)
+			}
+
+			for _, e := range validationErrs {
+				cmd.PrintErrf("%s\n", e.Error())
+			}
+
+			if HasErrors(validationErrs) {
+				return errors.New("apply aborted: one or more manifests failed validation (see above)")
 			}
 
 			var namespace string

--- a/cli/cmd/apply_test.go
+++ b/cli/cmd/apply_test.go
@@ -15,17 +15,17 @@
 package cmd
 
 import (
+	"errors"
+	"os"
+	"testing"
+
 	"drasi.io/cli/api"
 	"drasi.io/cli/output"
 	"drasi.io/cli/sdk"
 	"drasi.io/cli/testutil"
-	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"os"
-	"testing"
 )
-
 
 func TestApplyCommand(t *testing.T) {
 	t.Run("Success case - apply single manifest", func(t *testing.T) {
@@ -242,7 +242,8 @@ spec:
 
 		manifestContent := `apiVersion: v1
 kind: Source
-name: test-source`
+name: test-source
+spec: {}`
 		_, err = tempFile.WriteString(manifestContent)
 		assert.NoError(t, err)
 		tempFile.Close()
@@ -275,7 +276,8 @@ name: test-source`
 
 		manifestContent := `apiVersion: v1
 kind: Source
-name: test-source`
+name: test-source
+spec: {}`
 		_, err = tempFile.WriteString(manifestContent)
 		assert.NoError(t, err)
 		tempFile.Close()

--- a/cli/cmd/validator.go
+++ b/cli/cmd/validator.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"drasi.io/cli/api"
+	"gopkg.in/yaml.v3"
+)
+
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+type ValidationError struct {
+	Index    int      `json:"index"`
+	Severity Severity `json:"severity"`
+	Kind     string   `json:"kind,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	Message  string   `json:"message"`
+}
+
+func (e ValidationError) Error() string {
+	loc := fmt.Sprintf("Resource %d", e.Index)
+	if e.Kind != "" || e.Name != "" {
+		loc += fmt.Sprintf(" (%s/%s)", e.Kind, e.Name)
+	}
+	return fmt.Sprintf("[%s] %s: %s", e.Severity, loc, e.Message)
+}
+
+func HasErrors(errs []ValidationError) bool {
+	for _, e := range errs {
+		if e.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+var kindToSchema = map[string]string{
+	"ContinuousQuery":  "QuerySpecDto",
+	"QueryContainer":   "QueryContainerSpecDto",
+	"Source":           "SourceSpecDto",
+	"Reaction":         "ReactionSpecDto",
+	"SourceProvider":   "ProviderSpecDto",
+	"ReactionProvider": "ProviderSpecDto",
+}
+
+func schemaNameForKind(kind string) string {
+	if name, ok := kindToSchema[kind]; ok {
+		return name
+	}
+	return kind + "SpecDto"
+}
+
+func ValidateManifests(manifests []api.Manifest, openapiBytes []byte) ([]ValidationError, error) {
+	openapiSpec, err := loadOpenAPISpec(openapiBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse openapi.yaml: %w", err)
+	}
+
+	var errs []ValidationError
+	for i, m := range manifests {
+		errs = append(errs, validateManifest(i, m, openapiSpec)...)
+	}
+	return errs, nil
+}
+
+func loadOpenAPISpec(data []byte) (map[string]interface{}, error) {
+	var spec map[string]interface{}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, err
+	}
+	return spec, nil
+}
+
+func getNested(m map[string]interface{}, keys ...string) (interface{}, bool) {
+	var cur interface{} = m
+	for _, k := range keys {
+		mm, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		cur, ok = mm[k]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+func getMap(m map[string]interface{}, keys ...string) map[string]interface{} {
+	v, ok := getNested(m, keys...)
+	if !ok {
+		return nil
+	}
+	mm, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return mm
+}
+
+func fieldPresent(m map[string]interface{}, key string) bool {
+	v, ok := m[key]
+	if !ok {
+		return false
+	}
+	if s, ok := v.(string); ok {
+		return strings.TrimSpace(s) != ""
+	}
+	return v != nil
+}
+
+func validateManifest(index int, m api.Manifest, openapiSpec map[string]interface{}) []ValidationError {
+	var errs []ValidationError
+
+	newErr := func(sev Severity, kind, name, msg string) ValidationError {
+		return ValidationError{Index: index, Severity: sev, Kind: kind, Name: name, Message: msg}
+	}
+
+	if strings.TrimSpace(m.ApiVersion) == "" {
+		errs = append(errs, newErr(SeverityWarning, "", "", "'apiVersion' is missing (expected e.g. 'v1')"))
+	}
+
+	kind := strings.TrimSpace(m.Kind)
+	if kind == "" {
+		errs = append(errs, newErr(SeverityError, "", "", "'kind' is missing or empty"))
+		return errs
+	}
+
+	name := strings.TrimSpace(m.Name)
+	if name == "" {
+		errs = append(errs, newErr(SeverityError, kind, "", "'name' is missing or empty"))
+	}
+
+	if m.Spec == nil {
+		errs = append(errs, newErr(SeverityError, kind, name, "'spec' block is missing"))
+		return errs
+	}
+
+	spec, ok := m.Spec.(map[string]interface{})
+	if !ok {
+		errs = append(errs, newErr(SeverityError, kind, name,
+			fmt.Sprintf("'spec' must be a YAML map, got %T", m.Spec)))
+		return errs
+	}
+
+	schemaName := schemaNameForKind(kind)
+	schemas := getMap(openapiSpec, "components", "schemas")
+	schema := getMap(schemas, schemaName)
+
+	if schema == nil {
+		errs = append(errs, newErr(SeverityWarning, kind, name,
+			fmt.Sprintf("no OpenAPI schema found for kind %q (looked for %q) — skipping deep validation", kind, schemaName)))
+		return errs
+	}
+
+	if reqList, ok := getNested(schema, "required"); ok {
+		for _, r := range reqList.([]interface{}) {
+			field, ok := r.(string)
+			if !ok {
+				continue
+			}
+			if !fieldPresent(spec, field) {
+				errs = append(errs, newErr(SeverityError, kind, name,
+					fmt.Sprintf("spec: missing required field '%s'", field)))
+			}
+		}
+	}
+
+	switch kind {
+	case "ContinuousQuery":
+		errs = append(errs, validateContinuousQuery(index, kind, name, spec)...)
+	}
+
+	return errs
+}
+
+func validateContinuousQuery(index int, kind, name string, spec map[string]interface{}) []ValidationError {
+	var errs []ValidationError
+	newErr := func(sev Severity, msg string) ValidationError {
+		return ValidationError{Index: index, Severity: sev, Kind: kind, Name: name, Message: msg}
+	}
+
+	sources := getMap(spec, "sources")
+	if sources == nil {
+		errs = append(errs, newErr(SeverityError, "spec.sources: block is missing"))
+		return errs
+	}
+
+	subsRaw, ok := sources["subscriptions"]
+	if !ok || subsRaw == nil {
+		errs = append(errs, newErr(SeverityError, "spec.sources: missing required field 'subscriptions'"))
+	} else if subs, ok := subsRaw.([]interface{}); !ok || len(subs) == 0 {
+		errs = append(errs, newErr(SeverityError, "spec.sources.subscriptions: must be a non-empty list"))
+	}
+
+	return errs
+}

--- a/cli/cmd/validator_test.go
+++ b/cli/cmd/validator_test.go
@@ -1,0 +1,607 @@
+package cmd
+
+import (
+	"testing"
+
+	"drasi.io/cli/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// minimalOpenAPI is a small but realistic openapi.yaml fixture used across all tests. It includes the required fields for Source and ContinuousQuery, so manifests that include those fields should pass validation without errors.
+var minimalOpenAPI = []byte(`
+components:
+  schemas:
+    SourceSpecDto:
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+        dbhost:
+          type: string
+        dbport:
+          type: integer
+    QuerySpecDto:
+      required:
+        - query
+        - sources
+      properties:
+        query:
+          type: string
+        sources:
+          type: object
+`)
+
+func TestValidateManifests(t *testing.T) {
+
+	t.Run("Success case - valid Source manifest", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Name:       "my-source",
+				Spec: map[string]interface{}{
+					"kind":   "PostgreSQL",
+					"dbhost": "localhost",
+					"dbport": 5432,
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.Empty(t, errs)
+	})
+
+	t.Run("Success case - valid ContinuousQuery manifest", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "ContinuousQuery",
+				Name:       "my-query",
+				Spec: map[string]interface{}{
+					"query": "SELECT * FROM Users",
+					"sources": map[string]interface{}{
+						"subscriptions": []interface{}{
+							map[string]interface{}{"id": "my-source"},
+						},
+					},
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.Empty(t, errs)
+	})
+
+	t.Run("Success case - multiple valid manifests", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Name:       "my-source",
+				Spec: map[string]interface{}{
+					"kind": "PostgreSQL",
+				},
+			},
+			{
+				ApiVersion: "v1",
+				Kind:       "ContinuousQuery",
+				Name:       "my-query",
+				Spec: map[string]interface{}{
+					"query": "SELECT * FROM Users",
+					"sources": map[string]interface{}{
+						"subscriptions": []interface{}{
+							map[string]interface{}{"id": "my-source"},
+						},
+					},
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.Empty(t, errs)
+	})
+
+	t.Run("Error case - invalid openapi spec bytes", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{Kind: "Source", Name: "my-source"},
+		}
+
+		errs, err := ValidateManifests(manifests, []byte("{{invalid yaml"))
+
+		// Must return a hard error, not silent nil — so apply.go can block client.Apply()
+		assert.Error(t, err)
+		assert.Nil(t, errs)
+		assert.Contains(t, err.Error(), "could not parse openapi.yaml")
+	})
+
+	t.Run("Error case - nil openapi spec bytes", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				Kind: "Source",
+				Name: "my-source",
+				Spec: map[string]interface{}{
+					"kind": "PostgreSQL",
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, nil)
+
+		assert.NoError(t, err)
+		assert.True(t, len(errs) > 0)
+		for _, e := range errs {
+			assert.Equal(t, SeverityWarning, e.Severity)
+		}
+	})
+}
+
+func TestApiVersionValidation(t *testing.T) {
+
+	t.Run("Warning case - missing apiVersion", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				Kind: "Source",
+				Name: "my-source",
+				Spec: map[string]interface{}{"kind": "PostgreSQL"},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(errs))
+		assert.Equal(t, SeverityWarning, errs[0].Severity)
+		assert.Contains(t, errs[0].Message, "apiVersion")
+	})
+
+	t.Run("Warning case - whitespace-only apiVersion", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "   ",
+				Kind:       "Source",
+				Name:       "my-source",
+				Spec:       map[string]interface{}{"kind": "PostgreSQL"},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(errs))
+		assert.Equal(t, SeverityWarning, errs[0].Severity)
+		assert.Contains(t, errs[0].Message, "apiVersion")
+	})
+}
+
+func TestKindValidation(t *testing.T) {
+
+	t.Run("Error case - missing kind", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Name:       "my-source",
+				Spec:       map[string]interface{}{"kind": "PostgreSQL"},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+
+		kindErr := findError(errs, SeverityError)
+		assert.NotNil(t, kindErr)
+		assert.Contains(t, kindErr.Message, "kind")
+	})
+
+	t.Run("Warning case - unknown kind gets schema-not-found warning", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "UnknownResource",
+				Name:       "my-thing",
+				Spec:       map[string]interface{}{"foo": "bar"},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.False(t, HasErrors(errs))
+		assert.Equal(t, 1, len(errs))
+		assert.Equal(t, SeverityWarning, errs[0].Severity)
+		assert.Contains(t, errs[0].Message, "UnknownResource")
+	})
+}
+
+func TestNameValidation(t *testing.T) {
+
+	t.Run("Error case - missing name", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Spec:       map[string]interface{}{"kind": "PostgreSQL"},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		nameErr := findError(errs, SeverityError)
+		assert.NotNil(t, nameErr)
+		assert.Contains(t, nameErr.Message, "name")
+	})
+
+	t.Run("Error case - whitespace-only name", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Name:       "   ",
+				Spec:       map[string]interface{}{"kind": "PostgreSQL"},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		nameErr := findError(errs, SeverityError)
+		assert.NotNil(t, nameErr)
+		assert.Contains(t, nameErr.Message, "name")
+	})
+}
+
+func TestSpecValidation(t *testing.T) {
+
+	t.Run("Error case - nil spec", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Name:       "my-source",
+				Spec:       nil,
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		specErr := findError(errs, SeverityError)
+		assert.NotNil(t, specErr)
+		assert.Contains(t, specErr.Message, "spec")
+	})
+
+	t.Run("Error case - spec is not a map (string value)", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Name:       "my-source",
+				Spec:       "this-is-not-a-map",
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		specErr := findError(errs, SeverityError)
+		assert.NotNil(t, specErr)
+		assert.Contains(t, specErr.Message, "spec")
+	})
+
+	t.Run("Error case - spec is empty map, required fields missing", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Name:       "my-source",
+				Spec:       map[string]interface{}{},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		// Source requires 'kind' — should be flagged
+		assert.True(t, containsMessage(errs, "kind"))
+	})
+
+	t.Run("Success case - spec with boolean field present (false value)", func(t *testing.T) {
+
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Name:       "my-source",
+				Spec: map[string]interface{}{
+					"kind":    "PostgreSQL",
+					"enabled": false,
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.Empty(t, errs)
+	})
+
+	t.Run("Success case - spec with integer zero field present", func(t *testing.T) {
+		// fieldPresent must not treat int 0 as missing
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Name:       "my-source",
+				Spec: map[string]interface{}{
+					"kind":   "PostgreSQL",
+					"dbport": 0,
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.Empty(t, errs)
+	})
+}
+
+func TestContinuousQueryValidation(t *testing.T) {
+
+	t.Run("Error case - sources block missing", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "ContinuousQuery",
+				Name:       "my-query",
+				Spec: map[string]interface{}{
+					"query": "SELECT * FROM Users",
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		assert.True(t, containsMessage(errs, "sources"))
+	})
+
+	t.Run("Error case - subscriptions missing from sources", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "ContinuousQuery",
+				Name:       "my-query",
+				Spec: map[string]interface{}{
+					"query":   "SELECT * FROM Users",
+					"sources": map[string]interface{}{},
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		assert.True(t, containsMessage(errs, "subscriptions"))
+	})
+
+	t.Run("Error case - subscriptions is an empty list", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "ContinuousQuery",
+				Name:       "my-query",
+				Spec: map[string]interface{}{
+					"query": "SELECT * FROM Users",
+					"sources": map[string]interface{}{
+						"subscriptions": []interface{}{}, // empty
+					},
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		assert.True(t, containsMessage(errs, "subscriptions"))
+	})
+
+	t.Run("Error case - subscriptions is wrong type (not a list)", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "ContinuousQuery",
+				Name:       "my-query",
+				Spec: map[string]interface{}{
+					"query": "SELECT * FROM Users",
+					"sources": map[string]interface{}{
+						"subscriptions": "my-source", // string instead of list
+					},
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		assert.True(t, containsMessage(errs, "subscriptions"))
+	})
+
+	t.Run("Error case - query field missing", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "ContinuousQuery",
+				Name:       "my-query",
+				Spec: map[string]interface{}{
+					"sources": map[string]interface{}{
+						"subscriptions": []interface{}{
+							map[string]interface{}{"id": "my-source"},
+						},
+					},
+				},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+		assert.True(t, containsMessage(errs, "query"))
+	})
+}
+
+// ─────────────────────────────────────────────────────────────
+// HasErrors
+// ─────────────────────────────────────────────────────────────
+
+func TestHasErrors(t *testing.T) {
+
+	t.Run("Returns false for empty slice", func(t *testing.T) {
+		assert.False(t, HasErrors(nil))
+		assert.False(t, HasErrors([]ValidationError{}))
+	})
+
+	t.Run("Returns false for warnings only", func(t *testing.T) {
+		errs := []ValidationError{
+			{Severity: SeverityWarning, Message: "apiVersion missing"},
+		}
+		assert.False(t, HasErrors(errs))
+	})
+
+	t.Run("Returns true when at least one error exists", func(t *testing.T) {
+		errs := []ValidationError{
+			{Severity: SeverityWarning, Message: "apiVersion missing"},
+			{Severity: SeverityError, Message: "kind missing"},
+		}
+		assert.True(t, HasErrors(errs))
+	})
+
+	t.Run("Returns true for errors-only slice", func(t *testing.T) {
+		errs := []ValidationError{
+			{Severity: SeverityError, Message: "kind missing"},
+		}
+		assert.True(t, HasErrors(errs))
+	})
+}
+
+// ─────────────────────────────────────────────────────────────
+// ValidationError.Error() formatting
+// ─────────────────────────────────────────────────────────────
+
+func TestValidationErrorFormat(t *testing.T) {
+
+	t.Run("Formats with kind and name", func(t *testing.T) {
+		e := ValidationError{
+			Index:    0,
+			Severity: SeverityError,
+			Kind:     "Source",
+			Name:     "my-source",
+			Message:  "spec: missing required field 'kind'",
+		}
+		assert.Equal(t, "[error] Resource 0 (Source/my-source): spec: missing required field 'kind'", e.Error())
+	})
+
+	t.Run("Formats without kind and name", func(t *testing.T) {
+		e := ValidationError{
+			Index:    1,
+			Severity: SeverityWarning,
+			Message:  "'apiVersion' is missing",
+		}
+		assert.Equal(t, "[warning] Resource 1: 'apiVersion' is missing", e.Error())
+	})
+
+	t.Run("Formats with kind only (name empty)", func(t *testing.T) {
+		e := ValidationError{
+			Index:    2,
+			Severity: SeverityError,
+			Kind:     "Source",
+			Message:  "'name' is missing or empty",
+		}
+		assert.Equal(t, "[error] Resource 2 (Source/): 'name' is missing or empty", e.Error())
+	})
+}
+
+// ─────────────────────────────────────────────────────────────
+// Multi-manifest error indexing
+// ─────────────────────────────────────────────────────────────
+
+func TestErrorIndexing(t *testing.T) {
+
+	t.Run("Error index matches manifest position", func(t *testing.T) {
+		manifests := []api.Manifest{
+			{
+				ApiVersion: "v1",
+				Kind:       "Source",
+				Name:       "good-source",
+				Spec:       map[string]interface{}{"kind": "PostgreSQL"},
+			},
+			{
+				// index 1: missing kind — should produce error with Index=1
+				ApiVersion: "v1",
+				Name:       "bad-manifest",
+				Spec:       map[string]interface{}{},
+			},
+		}
+
+		errs, err := ValidateManifests(manifests, minimalOpenAPI)
+
+		assert.NoError(t, err)
+		assert.True(t, HasErrors(errs))
+
+		for _, e := range errs {
+			if e.Severity == SeverityError {
+				assert.Equal(t, 1, e.Index, "error should reference the second manifest (index 1)")
+			}
+		}
+	})
+}
+
+// ─────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────
+
+// findError returns the first ValidationError with the given severity, or nil.
+func findError(errs []ValidationError, sev Severity) *ValidationError {
+	for i := range errs {
+		if errs[i].Severity == sev {
+			return &errs[i]
+		}
+	}
+	return nil
+}
+
+// containsMessage returns true if any ValidationError message contains substr.
+func containsMessage(errs []ValidationError, substr string) bool {
+	for _, e := range errs {
+		if len(e.Message) > 0 {
+			// Use strings.Contains equivalent inline to avoid import
+			if len(e.Message) >= len(substr) {
+				for i := 0; i <= len(e.Message)-len(substr); i++ {
+					if e.Message[i:i+len(substr)] == substr {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
# Description

Adds a `validator` package that validates manifests against the embedded `openapi.yaml` 
schema before `client.Apply()` is called. Invalid manifests now print actionable errors 
and abort early — no API call is made.

Previously, `drasi apply` sent manifests directly to the API with no client-side 
validation, producing cryptic errors for missing fields and silently passing everything 
through if `openapi.yaml` was unparseable.

### Changes
- **`cmd/validator.go`** — new package with schema-driven required field checking, 
  two-tier severity (`SeverityWarning` / `SeverityError`), `HasErrors()` helper, and 
  per-kind extensible validators. Never writes to stderr directly — all issues returned 
  as structured `ValidationError`.
- **`cmd/apply.go`** — validation now runs between manifest parsing and `client.Apply()`. 
  Passes `[]api.Manifest` directly . Uses `cmd.PrintErrf()` 
  for capturable output.
- **`cmd/validator_test.go`** — 25 test cases covering valid manifests, missing 
  fields, wrong types, zero-value fields, unknown kinds, bad spec bytes, and error 
  formatting. Uses inline `openapi.yaml` fixture — no file I/O.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other 
  maintenance task and doesn't change the functionality of Drasi (issue link optional).

Fixes: #423 