### PR TITLE
Add per-reaction state store support

### DIFF
--- a/cli/installers/kubernetes_installer.go
+++ b/cli/installers/kubernetes_installer.go
@@ -325,6 +325,9 @@ func (t *KubernetesInstaller) createConfig(localMode bool, acr string, version s
 	}
 
 	cfg["DAPR_SIDECAR"] = "daprio/daprd:" + t.daprSidecarVersion
+	cfg["STATE_STORE_TYPE"] = "state.mongodb"
+	cfg["STATE_STORE_VERSION"] = "v1"
+	cfg["STATE_STORE_CONFIG"] = `[{"name":"connectionString","value":"mongodb://drasi-mongo:27017/?replicaSet=rs0"}]`
 	configMap := corev1apply.ConfigMap("drasi-config", t.kubeNamespace).WithData(cfg)
 
 	if _, err := t.kubeClient.CoreV1().ConfigMaps(t.kubeNamespace).Apply(context.TODO(), configMap, metav1.ApplyOptions{

--- a/cli/installers/kubernetes_manifest_installer.go
+++ b/cli/installers/kubernetes_manifest_installer.go
@@ -177,6 +177,9 @@ func (t *KubernetesManifestInstaller) generateConfigMapManifest(localMode bool, 
 	}
 
 	cfg["DAPR_SIDECAR"] = "daprio/daprd:" + t.daprSidecarVersion
+	cfg["STATE_STORE_TYPE"] = "state.mongodb"
+	cfg["STATE_STORE_VERSION"] = "v1"
+	cfg["STATE_STORE_CONFIG"] = `[{"name":"connectionString","value":"mongodb://drasi-mongo:27017/?replicaSet=rs0"}]`
 
 	configMap := map[string]interface{}{
 		"apiVersion": "v1",

--- a/cli/installers/resources/control-plane.yaml
+++ b/cli/installers/resources/control-plane.yaml
@@ -75,6 +75,24 @@ spec:
                   name: drasi-config
                   key: DAPR_SIDECAR
                   optional: true
+            - name: STATE_STORE_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: drasi-config
+                  key: STATE_STORE_TYPE
+                  optional: true
+            - name: STATE_STORE_VERSION
+              valueFrom:
+                configMapKeyRef:
+                  name: drasi-config
+                  key: STATE_STORE_VERSION
+                  optional: true
+            - name: STATE_STORE_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: drasi-config
+                  key: STATE_STORE_CONFIG
+                  optional: true
             - name: INGRESS_CLASS_NAME
               valueFrom:
                 configMapKeyRef:

--- a/control-planes/kubernetes_provider/src/controller/reconciler.rs
+++ b/control-planes/kubernetes_provider/src/controller/reconciler.rs
@@ -34,7 +34,7 @@ use kube::{
 };
 use serde::Serialize;
 
-use crate::models::Component;
+use crate::models::{Component, ResourceType};
 
 use super::super::models::{KubernetesSpec, RuntimeConfig};
 
@@ -281,6 +281,96 @@ impl ResourceReconciler {
             }
         }
 
+        if let Some(pub_sub) = &self.spec.pub_sub {
+            self.delete_component(pub_sub.metadata.name.as_ref().unwrap())
+                .await?;
+        }
+
+        if let Some(state_store) = &self.spec.state_store {
+            self.delete_component(state_store.metadata.name.as_ref().unwrap())
+                .await?;
+        } else if self.spec.pub_sub.is_some()
+            && matches!(&self.spec.resource_type, ResourceType::Reaction)
+        {
+            self.delete_managed_component(&format!("drasi-statestore-{}", self.spec.resource_id))
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn delete_managed_component(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+        match self.component_api.get(name).await {
+            Ok(component) => {
+                let labels = component.metadata.labels.unwrap_or_default();
+                let resource_type = self.spec.resource_type.to_string();
+                let is_managed = labels.get("drasi/type") == Some(&resource_type)
+                    && labels.get("drasi/resource") == Some(&self.spec.resource_id);
+
+                if is_managed {
+                    self.delete_component(name).await?;
+                } else {
+                    log::warn!("Component {} is not managed by this resource", name);
+                }
+            }
+            Err(kube::Error::Api(api_err)) if api_err.code == 404 => {}
+            Err(kube::Error::Api(api_err)) => return Err(Box::new(api_err)),
+            Err(err) => return Err(Box::new(err)),
+        }
+
+        Ok(())
+    }
+
+    async fn delete_component(&self, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+        log::info!("Deleting component {}", name);
+        let pp = DeleteParams::default();
+        if let Err(err) = self.component_api.delete(name, &pp).await {
+            match err {
+                kube::Error::Api(api_err) if api_err.code == 404 => {}
+                kube::Error::Api(api_err) => return Err(Box::new(api_err)),
+                _ => return Err(Box::new(err)),
+            }
+        }
+        Ok(())
+    }
+
+    async fn reconcile_component(
+        &self,
+        component: &Component,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let name = component.metadata.name.as_ref().unwrap();
+        match self.component_api.get(name).await {
+            Ok(current) => {
+                if current.spec != component.spec
+                    || current.metadata.labels != component.metadata.labels
+                {
+                    log::info!("Updating component {}", name);
+                    let mut replacement = component.clone();
+                    replacement.metadata.resource_version = current.metadata.resource_version;
+                    let pp = PostParams::default();
+                    self.component_api.replace(name, &pp, &replacement).await?;
+                }
+            }
+            Err(kube::Error::Api(api_err)) if api_err.code == 404 => {
+                log::info!("Creating component {}", name);
+                let pp = PostParams::default();
+                if let Err(err) = self.component_api.create(&pp, component).await {
+                    match err {
+                        kube::Error::Api(api_err) if api_err.code == 409 => {
+                            log::debug!("Component {} was created concurrently", name);
+                        }
+                        kube::Error::Api(api_err) => return Err(Box::new(api_err)),
+                        _ => return Err(Box::new(err)),
+                    }
+                }
+            }
+            Err(kube::Error::Api(api_err)) => {
+                log::error!("Error getting component {}: {}", name, api_err.code);
+                return Err(Box::new(api_err));
+            }
+            Err(e) => return Err(Box::new(e)),
+        }
+
         Ok(())
     }
 
@@ -288,28 +378,16 @@ impl ResourceReconciler {
         log::info!("Reconciling components {}", self.spec.resource_id);
 
         if let Some(pub_sub) = &self.spec.pub_sub {
-            let name = &pub_sub.metadata.name.clone().unwrap();
-            match self.component_api.get(name).await {
-                Ok(current) => {
-                    if current.spec != pub_sub.spec {
-                        log::info!("Updating component {}", name);
-                        let pp = PostParams::default();
-                        _ = self.component_api.replace(name, &pp, pub_sub).await?;
-                    }
-                }
-                Err(e) => match e {
-                    kube::Error::Api(api_err) => {
-                        if api_err.code != 404 {
-                            log::error!("Error getting pubsub component: {}", api_err.code);
-                            return Err(Box::new(api_err));
-                        }
-                        log::info!("Creating component {}", name);
-                        let pp = PostParams::default();
-                        _ = self.component_api.create(&pp, pub_sub).await?;
-                    }
-                    _ => return Err(Box::new(e)),
-                },
-            }
+            self.reconcile_component(pub_sub).await?;
+        }
+
+        if let Some(state_store) = &self.spec.state_store {
+            self.reconcile_component(state_store).await?;
+        } else if self.spec.pub_sub.is_some()
+            && matches!(&self.spec.resource_type, ResourceType::Reaction)
+        {
+            self.delete_managed_component(&format!("drasi-statestore-{}", self.spec.resource_id))
+                .await?;
         }
 
         Ok(())

--- a/control-planes/kubernetes_provider/src/models.rs
+++ b/control-planes/kubernetes_provider/src/models.rs
@@ -37,6 +37,8 @@ pub struct KubernetesSpec {
     pub volume_claims: BTreeMap<String, PersistentVolumeClaim>,
     pub ingresses: Option<BTreeMap<String, Ingress>>,
     pub pub_sub: Option<Component>,
+    #[serde(default)]
+    pub state_store: Option<Component>,
     pub service_account: Option<ServiceAccount>,
     pub removed: bool,
 }
@@ -58,6 +60,7 @@ impl KubernetesSpec {
             volume_claims: BTreeMap::new(),
             ingresses: Some(BTreeMap::new()),
             pub_sub: None,
+            state_store: None,
             service_account: None,
             removed: false,
         }
@@ -103,6 +106,9 @@ pub struct RuntimeConfig {
     pub pub_sub_type: String,
     pub pub_sub_version: String,
     pub pub_sub_config: Vec<EnvVar>,
+    pub state_store_type: String,
+    pub state_store_version: String,
+    pub state_store_config: Vec<EnvVar>,
     pub ingress_class_name: String,
     pub ingress_load_balancer_service: String,
     pub ingress_load_balancer_namespace: String,
@@ -136,6 +142,16 @@ impl RuntimeConfig {
             },
         ];
 
+        let state_store_config = match std::env::var("STATE_STORE_CONFIG") {
+            Ok(config) => serde_json::from_str(&config)
+                .unwrap_or_else(|e| panic!("Invalid STATE_STORE_CONFIG: {e}")),
+            Err(_) => vec![EnvVar {
+                name: "connectionString".to_string(),
+                value: Some("mongodb://drasi-mongo:27017/?replicaSet=rs0".to_string()),
+                value_from: None,
+            }],
+        };
+
         RuntimeConfig {
             image_prefix: match std::env::var("ACR") {
                 Ok(acr) => format!("{acr}/drasi-project/"),
@@ -166,6 +182,15 @@ impl RuntimeConfig {
                 Err(_) => "v1".to_string(),
             },
             pub_sub_config,
+            state_store_type: match std::env::var("STATE_STORE_TYPE") {
+                Ok(state_store_type) => state_store_type,
+                Err(_) => "state.mongodb".to_string(),
+            },
+            state_store_version: match std::env::var("STATE_STORE_VERSION") {
+                Ok(state_store_version) => state_store_version,
+                Err(_) => "v1".to_string(),
+            },
+            state_store_config,
             ingress_class_name: match std::env::var("INGRESS_CLASS_NAME") {
                 Ok(class_name) => class_name,
                 Err(_) => "contour".to_string(),

--- a/control-planes/kubernetes_provider/src/spec_builder/query_container.rs
+++ b/control-planes/kubernetes_provider/src/spec_builder/query_container.rs
@@ -78,6 +78,7 @@ impl SpecBuilder<QueryContainerSpec> for QueryContainerSpecBuilder {
             volume_claims: BTreeMap::new(),
             ingresses: None,
             pub_sub: None,
+            state_store: None,
             service_account: None,
             removed: false,
         });
@@ -230,6 +231,7 @@ impl SpecBuilder<QueryContainerSpec> for QueryContainerSpecBuilder {
             volume_claims: persistent_volume_claims,
             ingresses: None,
             pub_sub: None,
+            state_store: None,
             service_account: None,
             removed: false,
         });
@@ -279,6 +281,7 @@ impl SpecBuilder<QueryContainerSpec> for QueryContainerSpecBuilder {
             volume_claims: BTreeMap::new(),
             ingresses: None,
             pub_sub: None,
+            state_store: None,
             service_account: None,
             removed: false,
         });

--- a/control-planes/kubernetes_provider/src/spec_builder/reaction.rs
+++ b/control-planes/kubernetes_provider/src/spec_builder/reaction.rs
@@ -75,9 +75,24 @@ impl SpecBuilder<ReactionSpec> for ReactionSpecBuilder {
             },
         );
 
+        let state_store_name = format!("drasi-statestore-{}", reaction.id);
+        if reaction.spec.state_store {
+            env.insert(
+                "StateStoreName".to_string(),
+                ConfigValue::Inline {
+                    value: state_store_name.clone(),
+                },
+            );
+        }
+
+        let mut component_labels = BTreeMap::new();
+        component_labels.insert("drasi/type".to_string(), ResourceType::Reaction.to_string());
+        component_labels.insert("drasi/resource".to_string(), reaction.id.to_string());
+
         let services = reaction.spec.services.clone().unwrap_or_default();
 
         for (service_name, service_spec) in services {
+            let owns_components = specs.is_empty();
             let mut config_volumes = BTreeMap::new();
             let mut config_maps = BTreeMap::new();
 
@@ -257,16 +272,28 @@ impl SpecBuilder<ReactionSpec> for ReactionSpecBuilder {
                 config_maps,
                 volume_claims: BTreeMap::new(),
                 ingresses: Some(k8s_ingresses),
-                pub_sub: Some(Component {
+                pub_sub: owns_components.then(|| Component {
                     metadata: ObjectMeta {
                         name: Some(pub_sub_name.clone()),
-                        labels: Some(labels.clone()),
+                        labels: Some(component_labels.clone()),
                         ..Default::default()
                     },
                     spec: ComponentSpec {
                         _type: runtime_config.pub_sub_type.clone(),
                         version: runtime_config.pub_sub_version.clone(),
                         metadata: pub_sub_metadata,
+                    },
+                }),
+                state_store: (owns_components && reaction.spec.state_store).then(|| Component {
+                    metadata: ObjectMeta {
+                        name: Some(state_store_name.clone()),
+                        labels: Some(component_labels.clone()),
+                        ..Default::default()
+                    },
+                    spec: ComponentSpec {
+                        _type: runtime_config.state_store_type.clone(),
+                        version: runtime_config.state_store_version.clone(),
+                        metadata: runtime_config.state_store_config.clone(),
                     },
                 }),
                 service_account: None,
@@ -290,4 +317,100 @@ fn calc_hash<T: Serialize>(obj: &T) -> String {
     data.hash(&mut hash);
     let hsh = hash.finish();
     format!("{hsh:02x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use resource_provider_api::models::Service;
+    use std::collections::HashMap;
+
+    fn build_specs(state_store: bool, service_count: usize) -> Vec<KubernetesSpec> {
+        let services = (0..service_count)
+            .map(|index| {
+                (
+                    format!("service-{index}"),
+                    Service {
+                        replica: None,
+                        image: "reaction-image".to_string(),
+                        external_image: Some(true),
+                        endpoints: None,
+                        dapr: None,
+                        properties: None,
+                    },
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        ReactionSpecBuilder {}.build(
+            ResourceRequest {
+                id: "my-reaction".to_string(),
+                spec: ReactionSpec {
+                    kind: "TestReaction".to_string(),
+                    tag: None,
+                    services: Some(services),
+                    properties: None,
+                    queries: HashMap::new(),
+                    identity: None,
+                    state_store,
+                },
+            },
+            &RuntimeConfig::default(),
+            "instance-id",
+        )
+    }
+
+    fn env_value<'a>(spec: &'a KubernetesSpec, name: &str) -> Option<&'a str> {
+        spec.deployment.template.spec.as_ref().unwrap().containers[0]
+            .env
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|env| env.name == name)
+            .and_then(|env| env.value.as_deref())
+    }
+
+    #[test]
+    fn creates_one_state_store_for_a_multi_service_reaction() {
+        let specs = build_specs(true, 2);
+
+        assert_eq!(specs.len(), 2);
+        assert_eq!(
+            specs.iter().filter(|spec| spec.pub_sub.is_some()).count(),
+            1
+        );
+        assert_eq!(
+            specs
+                .iter()
+                .filter(|spec| spec.state_store.is_some())
+                .count(),
+            1
+        );
+
+        for spec in &specs {
+            assert_eq!(
+                env_value(spec, "StateStoreName"),
+                Some("drasi-statestore-my-reaction")
+            );
+        }
+
+        let state_store = specs
+            .iter()
+            .find_map(|spec| spec.state_store.as_ref())
+            .unwrap();
+        assert_eq!(
+            state_store.metadata.name.as_deref(),
+            Some("drasi-statestore-my-reaction")
+        );
+        assert_eq!(state_store.spec._type, "state.mongodb");
+        assert_eq!(state_store.spec.version, "v1");
+    }
+
+    #[test]
+    fn omits_state_store_when_provider_does_not_request_one() {
+        let specs = build_specs(false, 1);
+
+        assert!(specs[0].state_store.is_none());
+        assert_eq!(env_value(&specs[0], "StateStoreName"), None);
+    }
 }

--- a/control-planes/kubernetes_provider/src/spec_builder/source.rs
+++ b/control-planes/kubernetes_provider/src/spec_builder/source.rs
@@ -79,6 +79,7 @@ impl SpecBuilder<SourceSpec> for SourceSpecBuilder {
             volume_claims: BTreeMap::new(),
             ingresses: None,
             pub_sub: None,
+            state_store: None,
             service_account: None,
             removed: false,
         });
@@ -110,6 +111,7 @@ impl SpecBuilder<SourceSpec> for SourceSpecBuilder {
             volume_claims: BTreeMap::new(),
             ingresses: None,
             pub_sub: None,
+            state_store: None,
             service_account: None,
             removed: false,
         });
@@ -158,6 +160,7 @@ impl SpecBuilder<SourceSpec> for SourceSpecBuilder {
             volume_claims: BTreeMap::new(),
             ingresses: None,
             pub_sub: None,
+            state_store: None,
             service_account: None,
             removed: false,
         });
@@ -343,6 +346,7 @@ impl SpecBuilder<SourceSpec> for SourceSpecBuilder {
                     Some(k8s_ingresses)
                 },
                 pub_sub: None,
+                state_store: None,
                 service_account: None,
                 removed: false,
             };

--- a/control-planes/mgmt_api/openapi.yaml
+++ b/control-planes/mgmt_api/openapi.yaml
@@ -997,6 +997,13 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ProviderServiceDto'
+        state_store:
+          type: boolean
+          description: |-
+            Whether resources using this provider require a per-resource Dapr state-store
+            component. Currently provisioned for reactions; source support is reserved for
+            a future release.
+          nullable: true
     QueryContainerDto:
       type: object
       required:

--- a/control-planes/mgmt_api/src/api/v1/mappings/providers.rs
+++ b/control-planes/mgmt_api/src/api/v1/mappings/providers.rs
@@ -215,6 +215,7 @@ impl From<ProviderSpecDto> for ProviderSpec {
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
             config_schema: provider_spec.config_schema.map(|schema| schema.into()),
+            state_store: provider_spec.state_store.unwrap_or_default(),
         }
     }
 }
@@ -228,6 +229,7 @@ impl From<ProviderSpec> for ProviderSpecDto {
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
             config_schema: provider_spec.config_schema.map(|schema| schema.into()),
+            state_store: provider_spec.state_store.then_some(true),
         }
     }
 }

--- a/control-planes/mgmt_api/src/api/v1/mappings/reaction.rs
+++ b/control-planes/mgmt_api/src/api/v1/mappings/reaction.rs
@@ -43,6 +43,7 @@ impl From<ReactionSpecDto> for ReactionSpec {
                 .map(|(k, v)| (k, v.unwrap_or_default()))
                 .collect(),
             identity: spec.identity.map(|identity| identity.into()),
+            state_store: false,
         }
     }
 }

--- a/control-planes/mgmt_api/src/api/v1/models/providers.rs
+++ b/control-planes/mgmt_api/src/api/v1/models/providers.rs
@@ -24,6 +24,11 @@ use super::ConfigValueDto;
 pub struct ProviderSpecDto {
     pub services: HashMap<String, ProviderServiceDto>,
     pub config_schema: Option<JsonSchemaDto>,
+    /// Whether resources using this provider require a per-resource Dapr state-store
+    /// component. Currently provisioned for reactions; source support is reserved for
+    /// a future release.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_store: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, ToSchema)]

--- a/control-planes/mgmt_api/src/domain/mappings.rs
+++ b/control-planes/mgmt_api/src/domain/mappings.rs
@@ -131,6 +131,7 @@ impl From<ReactionSpec> for resource_provider_api::models::ReactionSpec {
                 .map(|properties| properties.into_iter().map(|(k, v)| (k, v.into())).collect()),
             queries: reaction_spec.queries,
             identity: reaction_spec.identity.map(|identity| identity.into()),
+            state_store: reaction_spec.state_store,
         }
     }
 }

--- a/control-planes/mgmt_api/src/domain/models.rs
+++ b/control-planes/mgmt_api/src/domain/models.rs
@@ -121,6 +121,8 @@ pub struct ReactionSpec {
     pub properties: Option<HashMap<String, ConfigValue>>,
     pub queries: HashMap<String, String>,
     pub identity: Option<ServiceIdentity>,
+    #[serde(default)]
+    pub state_store: bool,
 }
 
 impl HasKind for ReactionSpec {
@@ -230,6 +232,8 @@ pub struct SourceProviderStatus {
 pub struct ProviderSpec {
     pub services: HashMap<String, ProviderService>,
     pub config_schema: Option<JsonSchema>,
+    #[serde(default)]
+    pub state_store: bool,
 }
 
 pub struct SourceProviderMarker;

--- a/control-planes/mgmt_api/src/domain/resource_services/extensible/reaction_service.rs
+++ b/control-planes/mgmt_api/src/domain/resource_services/extensible/reaction_service.rs
@@ -322,5 +322,33 @@ fn populate_default_values(
         properties: Some(properties),
         queries: reaction.queries.clone(),
         identity: reaction.identity.clone(),
+        state_store: schema_json.state_store,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_state_store_dependency_from_provider() {
+        let reaction = ReactionSpec {
+            kind: "StatefulReaction".to_string(),
+            tag: None,
+            services: Some(HashMap::new()),
+            properties: Some(HashMap::new()),
+            queries: HashMap::new(),
+            identity: None,
+            state_store: false,
+        };
+        let provider = ProviderSpec {
+            services: HashMap::new(),
+            config_schema: None,
+            state_store: true,
+        };
+
+        let populated = populate_default_values(&reaction, &provider).unwrap();
+
+        assert!(populated.state_store);
+    }
 }

--- a/control-planes/resource_provider_api/src/models.rs
+++ b/control-planes/resource_provider_api/src/models.rs
@@ -162,6 +162,8 @@ pub struct ReactionSpec {
     pub properties: Option<HashMap<String, ConfigValue>>,
     pub queries: HashMap<String, String>,
     pub identity: Option<ServiceIdentity>,
+    #[serde(default)]
+    pub state_store: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/e2e-tests/10-reaction-statestore-scenario/reaction-provider.yaml
+++ b/e2e-tests/10-reaction-statestore-scenario/reaction-provider.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ReactionProvider
+name: PythonStateStoreE2E
+spec:
+  state_store: true
+  services:
+    python:
+      image: drasi-project/e2e-python-state-reaction:latest
+      externalImage: true

--- a/e2e-tests/10-reaction-statestore-scenario/reaction-statestore.test.js
+++ b/e2e-tests/10-reaction-statestore-scenario/reaction-statestore.test.js
@@ -1,0 +1,193 @@
+const { afterAll, beforeAll, describe, expect, test } = require('@jest/globals');
+const axios = require('axios');
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const deleteResources = require('../fixtures/delete-resources');
+const deployResources = require('../fixtures/deploy-resources');
+const PortForward = require('../fixtures/port-forward');
+const { waitFor, waitForChildProcess } = require('../fixtures/infrastructure');
+
+const SCENARIO_DIR = __dirname;
+const REPOSITORY_ROOT = path.resolve(SCENARIO_DIR, '..', '..');
+const PYTHON_SDK_ROOT = path.join(REPOSITORY_ROOT, 'reactions', 'sdk', 'python');
+const REACTION_PROVIDER_FILE = path.join(SCENARIO_DIR, 'reaction-provider.yaml');
+const REACTION_FILE = path.join(SCENARIO_DIR, 'reaction.yaml');
+const REACTION_IMAGE = 'drasi-project/e2e-python-state-reaction:latest';
+const REACTION_ID = 'python-state-store-e2e';
+const REACTION_SERVICE = 'python';
+const DEPLOYMENT_NAME = `${REACTION_ID}-${REACTION_SERVICE}`;
+const APP_ID = DEPLOYMENT_NAME;
+const COMPONENT_NAME = `drasi-statestore-${REACTION_ID}`;
+const NAMESPACE = 'drasi-system';
+
+function loadYaml(filePath) {
+  return yaml.loadAll(fs.readFileSync(filePath, 'utf8')).filter(Boolean);
+}
+
+async function buildAndLoadReactionImage() {
+  await waitForChildProcess(
+    cp.spawn('docker', [
+      'build',
+      '-f',
+      path.join(PYTHON_SDK_ROOT, 'examples', 'state-store', 'Dockerfile'),
+      '-t',
+      REACTION_IMAGE,
+      PYTHON_SDK_ROOT,
+    ]),
+    'python-state-reaction-build',
+  );
+  await waitForChildProcess(
+    cp.spawn('kind', [
+      'load',
+      'docker-image',
+      REACTION_IMAGE,
+      '--name',
+      'drasi-test',
+    ]),
+    'python-state-reaction-load',
+  );
+}
+
+function getComponent() {
+  try {
+    return JSON.parse(
+      cp.execFileSync(
+        'kubectl',
+        ['get', 'component', COMPONENT_NAME, '-n', NAMESPACE, '-o', 'json'],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+      ),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function getDeployment() {
+  return JSON.parse(
+    cp.execFileSync(
+      'kubectl',
+      ['get', 'deployment', DEPLOYMENT_NAME, '-n', NAMESPACE, '-o', 'json'],
+      { encoding: 'utf8' },
+    ),
+  );
+}
+
+describe('Reaction provider state store dependency', () => {
+  const reactionProviderResources = loadYaml(REACTION_PROVIDER_FILE);
+  const reactionResources = loadYaml(REACTION_FILE);
+  let portForward;
+  let daprPort;
+  let reactionDeleted = false;
+
+  beforeAll(async () => {
+    await buildAndLoadReactionImage();
+    await deployResources(reactionProviderResources);
+    await deployResources(reactionResources);
+
+    const component = await waitFor({
+      actionFn: getComponent,
+      predicateFn: value => value !== null,
+      timeoutMs: 30000,
+      description: `${COMPONENT_NAME} to be created`,
+    });
+    expect(component).not.toBeNull();
+
+    portForward = new PortForward(DEPLOYMENT_NAME, 3500, NAMESPACE, 'deployment');
+    daprPort = await portForward.start();
+  }, 300000);
+
+  afterAll(async () => {
+    portForward?.stop();
+    const cleanup = reactionDeleted
+      ? reactionProviderResources
+      : [...reactionResources, ...reactionProviderResources];
+    await deleteResources(cleanup);
+  }, 180000);
+
+  test('provisions, injects, persists, and removes the reaction state store', async () => {
+    const component = getComponent();
+    expect(component.spec.type).toBe('state.mongodb');
+    expect(component.spec.version).toBe('v1');
+
+    const deployment = getDeployment();
+    const reactionContainer = deployment.spec.template.spec.containers.find(
+      container => container.name === REACTION_SERVICE,
+    );
+    const stateStoreEnv = reactionContainer.env.find(
+      env => env.name === 'StateStoreName',
+    );
+    expect(stateStoreEnv.value).toBe(COMPONENT_NAME);
+
+    let sequence = 0;
+    const sendChange = async () => {
+      sequence += 1;
+      await axios.post(
+        `http://127.0.0.1:${daprPort}/v1.0/invoke/${APP_ID}/method/counter-query`,
+        {
+          data: {
+            kind: 'change',
+            queryId: 'counter-query',
+            sequence,
+            sourceTimeMs: Date.now(),
+            addedResults: [],
+            updatedResults: [],
+            deletedResults: [],
+          },
+        },
+        { timeout: 10000 },
+      );
+    };
+    const getCounter = async () => {
+      const response = await axios.get(
+        `http://127.0.0.1:${daprPort}/v1.0/state/${COMPONENT_NAME}/counter`,
+        { timeout: 10000 },
+      );
+      return Number(response.data);
+    };
+
+    await sendChange();
+    expect(await getCounter()).toBe(1);
+    await sendChange();
+    expect(await getCounter()).toBe(2);
+
+    portForward.stop();
+    await waitForChildProcess(
+      cp.exec(
+        `kubectl delete pod -n ${NAMESPACE} -l drasi/resource=${REACTION_ID} --wait=true`,
+        { encoding: 'utf8' },
+      ),
+      'delete-python-state-reaction-pod',
+    );
+    await waitForChildProcess(
+      cp.exec(
+        `kubectl wait --for=condition=Ready pod -n ${NAMESPACE} -l drasi/resource=${REACTION_ID} --timeout=180s`,
+        { encoding: 'utf8' },
+      ),
+      'wait-python-state-reaction-pod',
+    );
+
+    portForward = new PortForward(DEPLOYMENT_NAME, 3500, NAMESPACE, 'deployment');
+    daprPort = await portForward.start();
+    expect(await getCounter()).toBe(2);
+    await sendChange();
+    expect(await getCounter()).toBe(3);
+
+    cp.execSync('drasi delete', {
+      input: yaml.dump(reactionResources[0]),
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    reactionDeleted = true;
+
+    const deletedComponent = await waitFor({
+      actionFn: getComponent,
+      predicateFn: value => value === null,
+      timeoutMs: 30000,
+      description: `${COMPONENT_NAME} to be deleted`,
+    });
+    expect(deletedComponent).toBeNull();
+  }, 300000);
+});

--- a/e2e-tests/10-reaction-statestore-scenario/reaction.yaml
+++ b/e2e-tests/10-reaction-statestore-scenario/reaction.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Reaction
+name: python-state-store-e2e
+spec:
+  kind: PythonStateStoreE2E
+  queries:
+    counter-query:

--- a/e2e-tests/fixtures/port-forward.js
+++ b/e2e-tests/fixtures/port-forward.js
@@ -23,11 +23,13 @@ class PortForward {
  * @param {string} serviceName
  * @param {number} servicePort
  * @param {string} namespace
+ * @param {string} resourceType
  */
-  constructor(serviceName, servicePort, namespace = "default") {
+  constructor(serviceName, servicePort, namespace = "default", resourceType = "services") {
     this.serviceName = serviceName;
     this.servicePort = servicePort;
     this.namespace = namespace;
+    this.resourceType = resourceType;
   }
 
   /**
@@ -38,7 +40,7 @@ class PortForward {
     let localPort = await portfinder.getPortPromise();
 
     let promise = new Promise((resolve, reject) => {
-      let proc = cp.spawn("kubectl", ["port-forward", `services/${this.serviceName}`, `${localPort}:${this.servicePort}`, "-n", self.namespace]);
+      let proc = cp.spawn("kubectl", ["port-forward", `${this.resourceType}/${this.serviceName}`, `${localPort}:${this.servicePort}`, "-n", self.namespace]);
       
       proc.stdout.on('data', function(msg){         
         console.log(`PortForward: ${self.serviceName} ${msg.toString()}`);

--- a/reactions/sdk/python/.dockerignore
+++ b/reactions/sdk/python/.dockerignore
@@ -27,7 +27,6 @@
 !.git/packed-refs
 !.git/refs/heads/**
 LICENSE
-README.md
 
 **/__pycache__/
 **/*.py[cod]
@@ -56,5 +55,4 @@ var/
 .mypy_cache/
 .dmypy.json
 dmypy.json
-
 

--- a/reactions/sdk/python/README.md
+++ b/reactions/sdk/python/README.md
@@ -80,3 +80,55 @@ custom_reaction = DrasiReaction(
 # Start the Reaction
 custom_reaction.start()
 ```
+
+### Durable reaction state
+
+A ReactionProvider can request a dedicated Dapr state store by setting
+`state_store: true`:
+
+```yaml
+apiVersion: v1
+kind: ReactionProvider
+name: PythonStatefulReaction
+spec:
+  state_store: true
+  services:
+    reaction:
+      image: python-stateful-reaction
+```
+
+The platform injects the generated component name as `StateStoreName`. Use the
+official Dapr SDK to access it:
+
+```python
+import os
+
+from dapr.aio.clients import DaprClient
+
+async def update_routing_rules():
+    store_name = os.environ["StateStoreName"]
+
+    async with DaprClient() as client:
+        current = await client.get_state(
+            store_name=store_name,
+            key="routing-rules",
+        )
+        await client.save_state(
+            store_name=store_name,
+            key="routing-rules",
+            value='{"route": "agent"}',
+            etag=current.etag or None,
+        )
+```
+
+`get_state` returns the store ETag in `current.etag`. Passing it to
+`save_state` enables optimistic concurrency when the configured state store
+supports ETags. The Dapr SDK also provides consistency options, transactions,
+bulk operations, deletes, and request metadata.
+
+The platform creates a per-reaction Dapr Component, not a separate backing
+database. Components use the state store configured when Drasi is installed
+and are not currently scoped to the reaction's Dapr app IDs. Deleting a
+reaction removes its state-store and pub/sub Component resources, but does not
+purge records from the shared backing store. Recreating the same reaction ID
+may make its previous state accessible again.

--- a/reactions/sdk/python/examples/state-store/Dockerfile
+++ b/reactions/sdk/python/examples/state-store/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /sdk
+
+COPY pyproject.toml README.md ./
+COPY drasi ./drasi
+RUN pip install --no-cache-dir .
+
+WORKDIR /app
+COPY examples/state-store/main.py .
+
+ENTRYPOINT ["python", "-m", "main"]

--- a/reactions/sdk/python/examples/state-store/main.py
+++ b/reactions/sdk/python/examples/state-store/main.py
@@ -1,0 +1,32 @@
+import os
+from typing import Any
+
+from dapr.aio.clients import DaprClient
+from drasi.reaction.models.ChangeEvent import ChangeEvent
+from drasi.reaction.sdk import DrasiReaction
+
+STATE_STORE_NAME = os.environ["StateStoreName"]
+
+
+async def on_change_event(
+    _event: ChangeEvent, _query_config: dict[str, Any] | None
+) -> None:
+    async with DaprClient() as client:
+        current = await client.get_state(
+            store_name=STATE_STORE_NAME,
+            key="counter",
+        )
+        count = int(current.data.decode()) if current.data else 0
+        await client.save_state(
+            store_name=STATE_STORE_NAME,
+            key="counter",
+            value=str(count + 1),
+            etag=current.etag or None,
+        )
+
+
+reaction = DrasiReaction(on_change_event=on_change_event)
+
+
+if __name__ == "__main__":
+    reaction.start()


### PR DESCRIPTION
Closes #441

## Summary

- let reaction providers declare `state_store: true`
- provision and clean up per-reaction Dapr state store components
- inject `StateStoreName` into reaction services
- document direct Python Dapr SDK usage and add an end-to-end scenario

## Testing

- Rust, Go, and Python unit tests
- E2E scenario runs in PR CI