### PR TITLE
Define reliable Python Reaction SDK lifecycle and delivery

### DIFF
--- a/e2e-tests/10-reaction-statestore-scenario/reaction-statestore.test.js
+++ b/e2e-tests/10-reaction-statestore-scenario/reaction-statestore.test.js
@@ -120,13 +120,23 @@ describe('Reaction provider state store dependency', () => {
       env => env.name === 'StateStoreName',
     );
     expect(stateStoreEnv.value).toBe(COMPONENT_NAME);
+    const pubsubNameEnv = reactionContainer.env.find(
+      env => env.name === 'PubsubName',
+    );
+    expect(pubsubNameEnv.value).toBe(`drasi-pubsub-${REACTION_ID}`);
 
     let sequence = 0;
     const sendChange = async () => {
       sequence += 1;
-      await axios.post(
-        `http://127.0.0.1:${daprPort}/v1.0/invoke/${APP_ID}/method/counter-query`,
+      const response = await axios.post(
+        `http://127.0.0.1:${daprPort}/v1.0/invoke/${APP_ID}/method/_drasi/events/counter-query`,
         {
+          id: `counter-query-${sequence}`,
+          source: 'urn:drasi:e2e',
+          specversion: '1.0',
+          type: 'com.dapr.event.sent',
+          topic: 'counter-query-results',
+          pubsubname: pubsubNameEnv.value,
           data: {
             kind: 'change',
             queryId: 'counter-query',
@@ -139,6 +149,7 @@ describe('Reaction provider state store dependency', () => {
         },
         { timeout: 10000 },
       );
+      expect(response.data).toEqual({ status: 'SUCCESS' });
     };
     const getCounter = async () => {
       const response = await axios.get(

--- a/reactions/sdk/python/Makefile
+++ b/reactions/sdk/python/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-dependencies generate-types test package
+.PHONY: install-dependencies generate-types test integration-test package
 
 install-dependencies:
 	poetry install --with dev
@@ -14,6 +14,9 @@ generate-types:
 
 test:
 	poetry run pytest tests
+
+integration-test:
+	DAPR_INTEGRATION_TESTS=1 poetry run pytest tests/integration
 
 package:
 	@echo "No published python package yet"

--- a/reactions/sdk/python/README.md
+++ b/reactions/sdk/python/README.md
@@ -1,90 +1,133 @@
 # Reaction SDK for Python
 
-This library provides the building blocks and infrastructure to implement a [Drasi](https://drasi.io/) Reaction in python.
+This library provides the building blocks for implementing a [Drasi](https://drasi.io/) Reaction in Python.
 
-## Getting started
+## Install
 
-### Install the package
-
-```
+```shell
 pip install drasi_reaction_sdk
 ```
 
-### Simple example
+The SDK installs its routes and lifespan behavior into a caller-owned FastAPI application. The application, rather than the SDK, owns the ASGI server and process lifecycle.
 
-The following example logs the various parts of the incoming change event from a [Continuous Query](https://drasi.io/concepts/continuous-queries/).
+## Basic example
 
 ```python
+from fastapi import FastAPI
+
+from drasi.reaction import DeliveryOutcome, DrasiReaction, ReactionMessage
 from drasi.reaction.models.ChangeEvent import ChangeEvent
-from drasi.reaction.sdk import DrasiReaction
 
 
-async def change_event(event: ChangeEvent, query_configs: dict[str, Any] | None = None):
-    print(f"Received change sequence {event.sequence} for query {event.queryId}")
+async def on_change(
+    message: ReactionMessage[ChangeEvent, None],
+) -> DeliveryOutcome:
+    event = message.event
+    print(f"Received sequence {event.sequence} for query {event.queryId}")
 
-    if event.addedResults:
-        print(f"Added result: {event.addedResults}")
+    for result in event.addedResults:
+        print(f"Added result: {result}")
 
-    if event.deletedResults:
-        print(f"Removed result: {event.deletedResults}")
+    for result in event.deletedResults:
+        print(f"Deleted result: {result}")
 
-    if event.updatedResults:
-        print(
-            f"Updated result - before: {event.updatedResults[0].before}, after {event.updatedResults[0].after}"
-        )
+    for update in event.updatedResults:
+        print(f"Updated result: before={update.before}, after={update.after}")
+
+    return DeliveryOutcome.SUCCESS
 
 
-reaction = DrasiReaction(on_change_event=change_event)
-
-reaction.start()
+app = FastAPI()
+reaction = DrasiReaction(on_change_event=on_change)
+reaction.install(app)
 ```
 
-### Advanced example
+Run the application with an ASGI server:
 
-The following example illustrates 
- - Retrieving a configuration value from the Reaction manifest
- - Parsing the per query configuration object from Yaml
- - Process change events from the query
- - Process control events (start, stop, etc.) from the query
+```shell
+uvicorn main:app --host 0.0.0.0 --port 80
+```
+
+Build either example container from this directory so its Dockerfile can install the local SDK source:
+
+```shell
+docker build -f examples/simple/Dockerfile .
+docker build -f examples/advanced/Dockerfile .
+```
+
+## Delivery contract
+
+Each callback receives one `ReactionMessage` containing:
+
+- `event`: A typed `ChangeEvent` or `ControlEvent`.
+- `query`: The validated query ID, topic, and isolated query configuration.
+- `delivery`: Structurally validated CloudEvent context. Its `identity` property is the `(source, id)` pair for this publication and any redeliveries. Attribute values remain untrusted application input.
+
+Callbacks must return a `DeliveryOutcome`:
+
+| Outcome | Dapr behavior |
+| --- | --- |
+| `DeliveryOutcome.SUCCESS` | Acknowledge the message. |
+| `DeliveryOutcome.RETRY` | Request redelivery according to Dapr resiliency configuration. |
+| `DeliveryOutcome.DROP` | Drop the message or forward it to the configured dead-letter topic. |
+
+Returning `None`, returning another type, or raising an ordinary exception maps to `DeliveryOutcome.RETRY`.
+
+## Query configuration
+
+The keys in `spec.queries` are mounted as files in `/etc/queries`. During `install()`, the SDK discovers and parses all files before publishing one read-only registration snapshot. If any parser invocation fails, installation fails without publishing partial state.
+
+A missing query configuration directory fails installation because it indicates that the expected configuration volume is unavailable. An existing empty directory produces a valid empty registration snapshot.
 
 ```python
+from typing import Any
+
+from fastapi import FastAPI
+
+from drasi.reaction import DeliveryOutcome, DrasiReaction, ReactionMessage
 from drasi.reaction.models.ChangeEvent import ChangeEvent
 from drasi.reaction.models.ControlEvent import ControlEvent
-from drasi.reaction.sdk import DrasiReaction 
-from drasi.reaction.utils import get_config_value, parse_yaml
+from drasi.reaction.utils import get_config_value, yaml_query_configs
 
-# Retrieve the connection string from the Reaction configuration
-my_connection_string = get_config_value("MyConnectionString")
 
-# Define the function that will be called when a change event is received
-async def on_change_event(event: ChangeEvent, query_config: dict[str, Any] | None) -> None:
-    print(f"Received change signal for query {event.query_id}")
-    print(f"Passed in the query config: {query_config}")
-    
-    # do something else with the `event` and `query_config`
+connection_string = get_config_value("MyConnectionString")
 
-# Define the function that will be called when a control event is received
-async def on_control_event(event: ControlEvent, query_config: dict[str, Any] | None) -> None:
-    print(f"Received control signal: {event.control_signal} for query {event.query_id}")
-    print(f"Passed in the query config: {query_config}")
 
-print(f"Starting Drasi reaction with connection string: {my_connection_string}")
+async def on_change(
+    message: ReactionMessage[ChangeEvent, dict[str, Any]],
+) -> DeliveryOutcome:
+    query_config = message.query.config
+    # Use connection_string, query_config, and message.event here.
+    return DeliveryOutcome.SUCCESS
 
-# Configure the Reaction with the on_change_event and on_control_event functions
-custom_reaction = DrasiReaction(
-    on_change_event=on_change_event,
-    on_control_event=on_control_event,
-    parse_query_configs=parse_yaml,
+
+async def on_control(
+    message: ReactionMessage[ControlEvent, dict[str, Any]],
+) -> DeliveryOutcome:
+    print(message.event.controlSignal.kind)
+    return DeliveryOutcome.SUCCESS
+
+
+app = FastAPI()
+reaction = DrasiReaction[dict[str, Any]](
+    on_change_event=on_change,
+    on_control_event=on_control,
+    parse_query_configs=yaml_query_configs,
 )
-
-# Start the Reaction
-custom_reaction.start()
+reaction.install(app)
 ```
 
-### Durable reaction state
+If no parser is supplied, each registration has `config=None`. Configuration objects passed to callbacks are isolated copies, so callback mutation cannot change the startup snapshot.
 
-A ReactionProvider can request a dedicated Dapr state store by setting
-`state_store: true`:
+The SDK reads:
+
+- `PubsubName`, defaulting to `drasi-pubsub`.
+- `QueryConfigPath`, defaulting to `/etc/queries`.
+- Other Reaction properties through `get_config_value()`.
+
+## Durable reaction state
+
+A ReactionProvider can request a dedicated Dapr state store by setting `state_store: true`:
 
 ```yaml
 apiVersion: v1
@@ -97,15 +140,19 @@ spec:
       image: python-stateful-reaction
 ```
 
-The platform injects the generated component name as `StateStoreName`. Use the
-official Dapr SDK to access it:
+The platform injects the generated component name as `StateStoreName`. Use the official Dapr SDK to access it:
 
 ```python
 import os
 
 from dapr.aio.clients import DaprClient
+from drasi.reaction import DeliveryOutcome, ReactionMessage
+from drasi.reaction.models.ChangeEvent import ChangeEvent
 
-async def update_routing_rules():
+
+async def update_routing_rules(
+    message: ReactionMessage[ChangeEvent, None],
+) -> DeliveryOutcome:
     store_name = os.environ["StateStoreName"]
 
     async with DaprClient() as client:
@@ -119,16 +166,50 @@ async def update_routing_rules():
             value='{"route": "agent"}',
             etag=current.etag or None,
         )
+
+    return DeliveryOutcome.SUCCESS
 ```
 
-`get_state` returns the store ETag in `current.etag`. Passing it to
-`save_state` enables optimistic concurrency when the configured state store
-supports ETags. The Dapr SDK also provides consistency options, transactions,
-bulk operations, deletes, and request metadata.
+`get_state` returns the store ETag in `current.etag`. Passing it to `save_state` enables optimistic concurrency when the configured state store supports ETags. The Dapr SDK also provides consistency options, transactions, bulk operations, deletes, and request metadata.
 
-The platform creates a per-reaction Dapr Component, not a separate backing
-database. Components use the state store configured when Drasi is installed
-and are not currently scoped to the reaction's Dapr app IDs. Deleting a
-reaction removes its state-store and pub/sub Component resources, but does not
-purge records from the shared backing store. Recreating the same reaction ID
-may make its previous state accessible again.
+The platform creates a per-reaction Dapr Component, not a separate backing database. Components use the state store configured when Drasi is installed and are not currently scoped to the reaction's Dapr app IDs. Deleting a reaction removes its state-store and pub/sub Component resources, but does not purge records from the shared backing store. Recreating the same reaction ID may make its previous state accessible again.
+
+## Initialization and cleanup
+
+Async initialization runs after the caller's FastAPI lifespan starts and before the application becomes ready. Cleanup runs once before the caller's lifespan shuts down.
+
+```python
+async def initialize() -> None:
+    ...
+
+
+async def cleanup() -> None:
+    ...
+
+
+reaction = DrasiReaction(
+    on_change_event=on_change,
+    on_initialize=initialize,
+    on_cleanup=cleanup,
+)
+reaction.install(app)
+```
+
+`reaction.is_ready` can be used by an application-owned readiness endpoint. The Dapr subscription endpoint returns `503` until initialization completes.
+
+## Dead-letter delivery
+
+Set one dead-letter topic for all query subscriptions:
+
+```python
+reaction = DrasiReaction(
+    on_change_event=on_change,
+    dead_letter_topic="reaction-dead-letter",
+)
+```
+
+Retry count and backoff remain part of the Dapr deployment and resiliency configuration.
+
+## Testing
+
+Run the unit and FastAPI suite with `make test`. Run the real-Dapr delivery suite with `make integration-test`; it requires the Dapr CLI and a local Dapr runtime and uses the in-memory pub/sub component.

--- a/reactions/sdk/python/drasi/reaction/__init__.py
+++ b/reactions/sdk/python/drasi/reaction/__init__.py
@@ -1,0 +1,15 @@
+from drasi.reaction.delivery import (
+    CloudEventContext,
+    DeliveryOutcome,
+    QueryRegistration,
+    ReactionMessage,
+)
+from drasi.reaction.sdk import DrasiReaction
+
+__all__ = [
+    "CloudEventContext",
+    "DeliveryOutcome",
+    "DrasiReaction",
+    "QueryRegistration",
+    "ReactionMessage",
+]

--- a/reactions/sdk/python/drasi/reaction/delivery.py
+++ b/reactions/sdk/python/drasi/reaction/delivery.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Generic, Mapping, TypeVar
+
+from drasi.reaction.models.ResultEvent import ResultEvent
+
+
+ConfigT = TypeVar("ConfigT")
+EventT = TypeVar("EventT", bound=ResultEvent)
+
+
+class DeliveryOutcome(str, Enum):
+    """The acknowledgement that the SDK returns to Dapr."""
+
+    SUCCESS = "SUCCESS"
+    RETRY = "RETRY"
+    DROP = "DROP"
+
+
+@dataclass(frozen=True)
+class CloudEventContext:
+    """Structurally validated delivery context from the outer Dapr CloudEvent."""
+
+    id: str
+    source: str
+    spec_version: str
+    type: str
+    topic: str
+    pubsub_name: str
+    attributes: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+
+    @property
+    def identity(self) -> tuple[str, str]:
+        """Identifies this CloudEvent publication and its redeliveries."""
+
+        return (self.source, self.id)
+
+
+@dataclass(frozen=True)
+class QueryRegistration(Generic[ConfigT]):
+    """A validated Continuous Query subscription."""
+
+    query_id: str
+    topic: str
+    config: ConfigT | None
+
+
+@dataclass(frozen=True)
+class ReactionMessage(Generic[EventT, ConfigT]):
+    """The typed message passed to a reaction callback."""
+
+    event: EventT
+    query: QueryRegistration[ConfigT]
+    delivery: CloudEventContext

--- a/reactions/sdk/python/drasi/reaction/logger.py
+++ b/reactions/sdk/python/drasi/reaction/logger.py
@@ -1,32 +1,13 @@
-import logging.config
-from typing import Any
-
-LOGGING_CONFIG: dict[str, Any] = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "default": {
-            "format": "%(levelname)s:\t  %(asctime)s %(name)s %(message)s",
-        },
-    },
-    "handlers": {
-        "stdout": {
-            "class": "logging.StreamHandler",
-            "level": "INFO",
-            "formatter": "default",
-            "stream": "ext://sys.stdout",
-        }
-    },
-    "loggers": {
-        "reaction.sdk": {
-            "handlers": ["stdout"],
-            "level": "INFO",
-            "propagate": False,
-        },
-    },
-}
+import logging
 
 
-def config_logging():
-    logging.config.dictConfig(LOGGING_CONFIG)
-    return logging.getLogger("reaction.sdk")
+LOGGER_NAME = "drasi.reaction.sdk"
+
+
+def get_logger() -> logging.Logger:
+    """Return the SDK logger without changing application logging configuration."""
+
+    logger = logging.getLogger(LOGGER_NAME)
+    if not logger.handlers:
+        logger.addHandler(logging.NullHandler())
+    return logger

--- a/reactions/sdk/python/drasi/reaction/sdk.py
+++ b/reactions/sdk/python/drasi/reaction/sdk.py
@@ -451,6 +451,7 @@ class DrasiReaction(Generic[ConfigT]):
                 with query_path.open("r", encoding="utf-8") as query_file:
                     parsed_config = self.parse_query_configs(query_file)
                 config = copy.deepcopy(parsed_config)
+                # Ensure the canonical snapshot can be copied for each delivery.
                 copy.deepcopy(config)
 
             registrations[query_id] = QueryRegistration(

--- a/reactions/sdk/python/drasi/reaction/sdk.py
+++ b/reactions/sdk/python/drasi/reaction/sdk.py
@@ -1,148 +1,749 @@
-""" Defines a `DrasiReaction` class for creating and registering reactions with Python
+"""Infrastructure for installing a Drasi Reaction into a FastAPI application."""
 
-Typical usage example:
-    
-    from drasi.reaction.models.ChangeEvent import ChangeEvent
-    from drasi.reaction.sdk import DrasiReaction
+from __future__ import annotations
 
-    async def change_func(data: ChangeEvent, query_config: dict[str, Any]):
-        print("my custom function")
-
-    dr = DrasiReaction(on_change_event=change_func)
-
-    df.start()
-"""
-
+import copy
+import json
+import logging
 import os
-import sys
-from io import TextIOWrapper
+import re
+from contextlib import asynccontextmanager
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Awaitable, Callable, TypeVar
+from types import MappingProxyType
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Generic,
+    Literal,
+    Mapping,
+    TextIO,
+    TypeVar,
+)
 
-import uvicorn
-from dapr.ext.fastapi import DaprApp
 from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from rfc3986_validator import validate_rfc3986
+from starlette.routing import Match
 
-from drasi.reaction.logger import config_logging
+from drasi.reaction.delivery import (
+    CloudEventContext,
+    DeliveryOutcome,
+    QueryRegistration,
+    ReactionMessage,
+)
+from drasi.reaction.logger import get_logger
 from drasi.reaction.models.ChangeEvent import ChangeEvent
 from drasi.reaction.models.ControlEvent import ControlEvent
 
-T = TypeVar("T")
 
-AsyncChangeEventFunc = Callable[[ChangeEvent, T | None], Awaitable[Any]]
-AsyncControlEventFunc = Callable[[ControlEvent, T | None], Awaitable[Any]]
+ConfigT = TypeVar("ConfigT")
+AsyncChangeEventFunc = Callable[
+    [ReactionMessage[ChangeEvent, ConfigT]], Awaitable[DeliveryOutcome]
+]
+AsyncControlEventFunc = Callable[
+    [ReactionMessage[ControlEvent, ConfigT]], Awaitable[DeliveryOutcome]
+]
+AsyncLifecycleFunc = Callable[[], Awaitable[None]]
+
+_CLOUD_EVENT_ATTRIBUTE_NAME = re.compile(r"^[a-z0-9]+$")
+_RFC3339_TIMESTAMP = re.compile(
+    r"^(?P<year>[0-9]{4})-(?P<month>[0-9]{2})-(?P<day>[0-9]{2})"
+    r"[Tt](?P<hour>[0-9]{2}):(?P<minute>[0-9]{2}):(?P<second>[0-9]{2})"
+    r"(?:\.[0-9]+)?(?P<offset>[Zz]|[+-][0-9]{2}:[0-9]{2})$"
+)
+_MIME_TSPECIALS = frozenset('()<>@,;:\\"/[]?=')
+_LEAP_SECOND_DATES = frozenset(
+    {
+        date(1972, 6, 30),
+        date(1972, 12, 31),
+        date(1973, 12, 31),
+        date(1974, 12, 31),
+        date(1975, 12, 31),
+        date(1976, 12, 31),
+        date(1977, 12, 31),
+        date(1978, 12, 31),
+        date(1979, 12, 31),
+        date(1981, 6, 30),
+        date(1982, 6, 30),
+        date(1983, 6, 30),
+        date(1985, 6, 30),
+        date(1987, 12, 31),
+        date(1989, 12, 31),
+        date(1990, 12, 31),
+        date(1992, 6, 30),
+        date(1993, 6, 30),
+        date(1994, 6, 30),
+        date(1995, 12, 31),
+        date(1997, 6, 30),
+        date(1998, 12, 31),
+        date(2005, 12, 31),
+        date(2008, 12, 31),
+        date(2012, 6, 30),
+        date(2015, 6, 30),
+        date(2016, 12, 31),
+    }
+)
+_MIN_CLOUD_EVENT_INTEGER = -(2**31)
+_MAX_CLOUD_EVENT_INTEGER = 2**31 - 1
+_DELIVERY_ROUTE = "/_drasi/events/{query_id}"
+_SUBSCRIPTION_ROUTE = "/dapr/subscribe"
+
+logger = get_logger()
 
 
-logger = config_logging()
+class _CloudEventEnvelope(BaseModel):
+    model_config = ConfigDict(extra="allow", frozen=True, strict=True)
+
+    id: str = Field(min_length=1)
+    source: str = Field(min_length=1)
+    specversion: Literal["1.0"]
+    type: str = Field(min_length=1)
+    datacontenttype: str | None = None
+    dataschema: str | None = None
+    subject: str | None = Field(default=None, min_length=1)
+    time: str | None = None
+    topic: str = Field(min_length=1)
+    pubsubname: str = Field(min_length=1)
+    data: dict[str, Any]
+
+    @field_validator("id", "type", "subject", "topic", "pubsubname")
+    @classmethod
+    def validate_string(cls, value: str | None) -> str | None:
+        if value is not None and not _is_cloud_event_string(value):
+            raise ValueError("attribute must be a valid CloudEvents string")
+        return value
+
+    @field_validator("source")
+    @classmethod
+    def validate_source(cls, value: str) -> str:
+        if validate_rfc3986(value, rule="URI_reference") is None:
+            raise ValueError("source must be a URI-reference")
+        return value
+
+    @field_validator("datacontenttype")
+    @classmethod
+    def validate_data_content_type(cls, value: str | None) -> str | None:
+        if value is not None and not _is_valid_media_type(value):
+            raise ValueError("datacontenttype must be a valid media type")
+        return value
+
+    @field_validator("dataschema")
+    @classmethod
+    def validate_data_schema(cls, value: str | None) -> str | None:
+        if value is not None and validate_rfc3986(value, rule="URI") is None:
+            raise ValueError("dataschema must be an absolute URI")
+        return value
+
+    @field_validator("time")
+    @classmethod
+    def validate_time(cls, value: str | None) -> str | None:
+        if value is not None and not _is_rfc3339_timestamp(value):
+            raise ValueError("time must be an RFC 3339 timestamp")
+        return value
 
 
-class DrasiReaction:
-    """Create and register Drasi Reactions for change and control events.
+def _is_cloud_event_string(value: str) -> bool:
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
 
-    Attributes:
-        on_change_event (AsyncChangeEventFunc): Callback function for handling change events.
-        on_control_event (AsyncControlEventFunc | None): Callback function for handling control events.
-        parse_query_configs (Callable[[TextIOWrapper], Any] | None): Function to parse query configurations.
-        port (int): Port on which the application runs.
-    """
+    for character in value:
+        code_point = ord(character)
+        if code_point <= 0x1F or 0x7F <= code_point <= 0x9F:
+            return False
+        if 0xFDD0 <= code_point <= 0xFDEF:
+            return False
+        if code_point & 0xFFFF in (0xFFFE, 0xFFFF):
+            return False
+    return True
+
+
+def _is_rfc3339_timestamp(value: str) -> bool:
+    match = _RFC3339_TIMESTAMP.fullmatch(value)
+    if match is None:
+        return False
+
+    parts = {
+        name: int(part) for name, part in match.groupdict().items() if name != "offset"
+    }
+    if parts["hour"] > 23 or parts["minute"] > 59 or parts["second"] > 60:
+        return False
+
+    offset = match.group("offset")
+    if offset in ("Z", "z"):
+        utc_offset = timedelta()
+    else:
+        offset_hour, offset_minute = (int(part) for part in offset[1:].split(":"))
+        if offset_hour > 23 or offset_minute > 59:
+            return False
+        direction = 1 if offset[0] == "+" else -1
+        utc_offset = direction * timedelta(
+            hours=offset_hour,
+            minutes=offset_minute,
+        )
+
+    try:
+        local_time = datetime(
+            parts["year"],
+            parts["month"],
+            parts["day"],
+            parts["hour"],
+            parts["minute"],
+            min(parts["second"], 59),
+            tzinfo=timezone(utc_offset),
+        )
+    except ValueError:
+        return False
+
+    if parts["second"] == 60:
+        try:
+            utc_time = local_time.astimezone(timezone.utc)
+        except OverflowError:
+            return False
+        return (
+            utc_time.date() in _LEAP_SECOND_DATES
+            and utc_time.hour == 23
+            and utc_time.minute == 59
+            and utc_time.second == 59
+        )
+
+    return True
+
+
+def _is_mime_token_character(character: str) -> bool:
+    return 0x21 <= ord(character) <= 0x7E and character not in _MIME_TSPECIALS
+
+
+def _consume_mime_token(value: str, position: int) -> int | None:
+    start = position
+    while position < len(value) and _is_mime_token_character(value[position]):
+        position += 1
+    return position if position > start else None
+
+
+def _consume_mime_whitespace_and_comments(
+    value: str,
+    position: int,
+) -> int | None:
+    while position < len(value):
+        while position < len(value) and value[position] == " ":
+            position += 1
+        if position >= len(value) or value[position] != "(":
+            return position
+
+        depth = 1
+        position += 1
+        while position < len(value) and depth:
+            character = value[position]
+            if character == "\\":
+                position += 2
+                if position > len(value):
+                    return None
+                continue
+            if character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+            position += 1
+        if depth:
+            return None
+    return position
+
+
+def _consume_mime_quoted_string(value: str, position: int) -> int | None:
+    if position >= len(value) or value[position] != '"':
+        return None
+    position += 1
+    while position < len(value):
+        character = value[position]
+        if character == '"':
+            return position + 1
+        if character == "\\":
+            position += 2
+            if position > len(value):
+                return None
+            continue
+        position += 1
+    return None
+
+
+def _is_valid_media_type(value: str) -> bool:
+    if not _is_cloud_event_string(value) or not value.isascii():
+        return False
+
+    position = _consume_mime_whitespace_and_comments(value, 0)
+    if position is None:
+        return False
+    position = _consume_mime_token(value, position)
+    if position is None:
+        return False
+    position = _consume_mime_whitespace_and_comments(value, position)
+    if position is None or position >= len(value) or value[position] != "/":
+        return False
+
+    position = _consume_mime_whitespace_and_comments(value, position + 1)
+    if position is None:
+        return False
+    position = _consume_mime_token(value, position)
+    if position is None:
+        return False
+
+    while True:
+        position = _consume_mime_whitespace_and_comments(value, position)
+        if position is None:
+            return False
+        if position == len(value):
+            return True
+        if value[position] != ";":
+            return False
+
+        position = _consume_mime_whitespace_and_comments(value, position + 1)
+        if position is None:
+            return False
+        position = _consume_mime_token(value, position)
+        if position is None:
+            return False
+        position = _consume_mime_whitespace_and_comments(value, position)
+        if position is None or position >= len(value) or value[position] != "=":
+            return False
+        position = _consume_mime_whitespace_and_comments(value, position + 1)
+        if position is None:
+            return False
+
+        quoted_end = _consume_mime_quoted_string(value, position)
+        if quoted_end is not None:
+            position = quoted_end
+            continue
+        position = _consume_mime_token(value, position)
+        if position is None:
+            return False
+
+
+class DrasiReaction(Generic[ConfigT]):
+    """Install typed Drasi delivery handlers into a caller-owned FastAPI app."""
 
     def __init__(
         self,
-        on_change_event: AsyncChangeEventFunc,
-        on_control_event: AsyncControlEventFunc | None = None,
-        parse_query_configs: Callable[[TextIOWrapper], Any] | None = None,
-        port: int = 80,
+        on_change_event: AsyncChangeEventFunc[ConfigT],
+        on_control_event: AsyncControlEventFunc[ConfigT] | None = None,
+        parse_query_configs: Callable[[TextIO], ConfigT] | None = None,
+        on_initialize: AsyncLifecycleFunc | None = None,
+        on_cleanup: AsyncLifecycleFunc | None = None,
+        dead_letter_topic: str | None = None,
     ) -> None:
-        """Initializes the DrasiReaction instance.
-
-        Args:
-            on_change_event (AsyncChangeEventFunc): Callback for handling change events.
-            on_control_event (AsyncControlEventFunc | None, optional): Callback for handling control events.
-                Defaults to None.
-            parse_query_configs (Callable[[TextIOWrapper], Any] | None, optional): Function to parse query configurations.
-                Defaults to None.
-            port (int, optional): Port for the application. Defaults to 80.
-        """
-
         self.on_change_event = on_change_event
         self.on_control_event = on_control_event
         self.parse_query_configs = parse_query_configs
-        self.port = port
+        self.on_initialize = on_initialize
+        self.on_cleanup = on_cleanup
+
+        if dead_letter_topic is not None and not dead_letter_topic.strip():
+            raise ValueError("dead_letter_topic must not be empty")
+        self.dead_letter_topic = dead_letter_topic
+
         self._pubsub_name = os.getenv("PubsubName", "drasi-pubsub")
         self._config_directory = Path(os.getenv("QueryConfigPath", "/etc/queries"))
-        self._app = FastAPI()
-        self._dapr_app = DaprApp(self._app)
-        self._query_configs: dict[str, Any] = {}
-
-    def subscribe(self):
-        """Subscribes to queries by reading configuration files and registering handlers."""
-
-        if self._config_directory.is_dir():
-            for query_path in self._config_directory.iterdir():
-                if query_path.is_file() and not query_path.name.startswith("."):
-                    query_id = query_path.stem
-
-                    logger.info(f"subscribing to query `{query_id}`")
-                    self.register_handler(query_id)
-
-                    if self.parse_query_configs:
-                        with open(query_path, "r") as f:
-                            self._query_configs[query_id] = self.parse_query_configs(f)
-        else:
-            logger.warning(
-                f"query directory `{str(self._config_directory)}` does not exist"
-            )
+        self._registrations: Mapping[str, QueryRegistration[ConfigT]] = (
+            MappingProxyType({})
+        )
+        self._subscriptions: tuple[dict[str, Any], ...] = ()
+        self._installed_app: FastAPI | None = None
+        self._ready = False
+        self._lifecycle_active = False
 
     @property
-    def query_configs(self):
-        """Gets the query configurations.
+    def is_ready(self) -> bool:
+        """Whether initialization completed and deliveries may be processed."""
 
-        Returns:
-            dict[str, Any]: The query configurations.
-        """
+        return self._ready
 
-        return self._query_configs
+    @property
+    def query_registrations(self) -> Mapping[str, QueryRegistration[ConfigT]]:
+        """Return an isolated, read-only copy of the startup registrations."""
 
-    def start(self):
-        """Starts the Drasi Reaction."""
+        return MappingProxyType(
+            {
+                query_id: self._copy_registration(registration)
+                for query_id, registration in self._registrations.items()
+            }
+        )
+
+    @property
+    def query_configs(self) -> Mapping[str, ConfigT | None]:
+        """Return isolated query configurations keyed by query ID."""
+
+        return MappingProxyType(
+            {
+                query_id: copy.deepcopy(registration.config)
+                for query_id, registration in self._registrations.items()
+            }
+        )
+
+    def install(self, app: FastAPI) -> None:
+        """Install Dapr discovery, delivery routes, and lifecycle behavior."""
+
+        if self._installed_app is not None:
+            raise RuntimeError("this reaction is already installed")
+        if getattr(app.state, "_drasi_reaction_installed", False):
+            raise RuntimeError("a Drasi reaction is already installed on this app")
+
+        registrations = self._prepare_registrations()
+        subscriptions = self._prepare_subscriptions(registrations)
+        self._preflight_routes(app, registrations)
+
+        original_route_count = len(app.router.routes)
+        original_lifespan = app.router.lifespan_context
 
         try:
-            self.subscribe()
-            logger.info("starting python reaction app")
-            uvicorn.run(self._app, host="127.0.0.1", port=self.port)
+            app.add_api_route(
+                _SUBSCRIPTION_ROUTE,
+                self._get_subscriptions,
+                methods=["GET"],
+                tags=["PubSub"],
+                name="drasi_subscriptions",
+                response_model=None,
+            )
+            app.add_api_route(
+                _DELIVERY_ROUTE,
+                self._handle_delivery,
+                methods=["POST"],
+                tags=["PubSub"],
+                name="drasi_delivery",
+            )
+            app.router.lifespan_context = self._compose_lifespan(original_lifespan)
+        except BaseException:
+            del app.router.routes[original_route_count:]
+            app.router.lifespan_context = original_lifespan
+            raise
 
-        except Exception as err:
-            logger.error(err)
-            with open("/dev/termination-log", "w") as f:
-                f.write(str(err))
-            sys.exit(1)
+        self._registrations = MappingProxyType(registrations)
+        self._subscriptions = tuple(subscriptions)
+        self._installed_app = app
+        app.state._drasi_reaction_installed = True
 
-    def register_handler(self, query_id: str):
-        """Registers a handler for a specific Drasi Query.
+    def _prepare_registrations(self) -> dict[str, QueryRegistration[ConfigT]]:
+        if not self._config_directory.exists():
+            raise FileNotFoundError(
+                f"query configuration directory does not exist: "
+                f"{self._config_directory}"
+            )
+        if not self._config_directory.is_dir():
+            raise NotADirectoryError(
+                f"query configuration path is not a directory: "
+                f"{self._config_directory}"
+            )
 
-        Args:
-            query_id (str): The ID of the query.
+        registrations: dict[str, QueryRegistration[ConfigT]] = {}
+        for query_path in sorted(self._config_directory.iterdir()):
+            if not query_path.is_file() or query_path.name.startswith("."):
+                continue
 
-        Returns:
-            Callable: The registered handler function.
-        """
+            query_id = query_path.name
+            topic = f"{query_id}-results"
+            config = None
 
-        @self._dapr_app.subscribe(
-            pubsub=self._pubsub_name, topic=f"{query_id}-results", route=f"/{query_id}"
+            if self.parse_query_configs is not None:
+                with query_path.open("r", encoding="utf-8") as query_file:
+                    parsed_config = self.parse_query_configs(query_file)
+                config = copy.deepcopy(parsed_config)
+                copy.deepcopy(config)
+
+            registrations[query_id] = QueryRegistration(
+                query_id=query_id,
+                topic=topic,
+                config=config,
+            )
+
+        return registrations
+
+    def _prepare_subscriptions(
+        self, registrations: Mapping[str, QueryRegistration[ConfigT]]
+    ) -> list[dict[str, Any]]:
+        subscriptions: list[dict[str, Any]] = []
+        for registration in registrations.values():
+            subscription: dict[str, Any] = {
+                "pubsubname": self._pubsub_name,
+                "topic": registration.topic,
+                "route": self._delivery_path(registration.query_id),
+            }
+            if self.dead_letter_topic is not None:
+                subscription["deadLetterTopic"] = self.dead_letter_topic
+            subscriptions.append(subscription)
+        return subscriptions
+
+    def _preflight_routes(
+        self,
+        app: FastAPI,
+        registrations: Mapping[str, QueryRegistration[ConfigT]],
+    ) -> None:
+        routes = [(_SUBSCRIPTION_ROUTE, "GET")]
+        routes.extend(
+            (self._delivery_path(query_id), "POST") for query_id in registrations
         )
-        async def handler(context: Request):
-            context_body = await context.json()
-            data = context_body.get("data", {})
 
-            query_config = self.query_configs.get(data.get("queryId"))
+        for path, method in routes:
+            scope = {
+                "type": "http",
+                "asgi": {"version": "3.0"},
+                "http_version": "1.1",
+                "scheme": "http",
+                "method": method,
+                "root_path": "",
+                "path": path,
+                "raw_path": path.encode("utf-8"),
+                "query_string": b"",
+                "headers": [],
+                "client": ("127.0.0.1", 0),
+                "server": ("127.0.0.1", 80),
+            }
+            for route in app.router.routes:
+                match, _ = route.matches(scope)
+                if match == Match.FULL:
+                    raise RuntimeError(
+                        f"cannot install Drasi route {method} {path}: "
+                        "an existing route would handle it first"
+                    )
 
-            kind = data.get("kind")
-            if kind == "change":
-                change_data = ChangeEvent.model_validate(data)
-                await self.on_change_event(change_data, query_config)
+    def _compose_lifespan(
+        self,
+        original_lifespan: Callable[[FastAPI], Any],
+    ) -> Callable[[FastAPI], Any]:
+        @asynccontextmanager
+        async def lifespan(app: FastAPI) -> AsyncIterator[Mapping[str, Any] | None]:
+            async with original_lifespan(app) as state:
+                if self._lifecycle_active:
+                    raise RuntimeError("the Drasi reaction lifecycle is already active")
 
-            if kind == "control" and self.on_control_event:
-                control_data = ControlEvent.model_validate(data)
-                await self.on_control_event(control_data, query_config)
+                self._lifecycle_active = True
+                primary_error: BaseException | None = None
+                try:
+                    if self.on_initialize is not None:
+                        await self.on_initialize()
+                    self._ready = True
+                    yield state
+                except BaseException as error:
+                    primary_error = error
+                finally:
+                    self._ready = False
+                    cleanup_error: BaseException | None = None
+                    try:
+                        if self.on_cleanup is not None:
+                            await self.on_cleanup()
+                    except BaseException as error:
+                        cleanup_error = error
+                        logger.error("reaction_cleanup_failed")
+                    finally:
+                        self._lifecycle_active = False
 
-        return handler
+                    if primary_error is not None:
+                        if cleanup_error is not None:
+                            raise primary_error from cleanup_error
+                        raise primary_error
+                    if cleanup_error is not None:
+                        raise cleanup_error
+
+        return lifespan
+
+    async def _get_subscriptions(self) -> list[dict[str, Any]] | JSONResponse:
+        if not self.is_ready:
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "reaction initialization is incomplete"},
+            )
+        return [dict(subscription) for subscription in self._subscriptions]
+
+    async def _handle_delivery(self, query_id: str, request: Request) -> dict[str, str]:
+        if not self.is_ready:
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.RETRY,
+                reason="not_ready",
+            )
+        if query_id not in self._registrations:
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.DROP,
+                reason="unregistered_query",
+            )
+
+        try:
+            payload = await request.json()
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.DROP,
+                reason="invalid_json",
+            )
+
+        try:
+            envelope = _CloudEventEnvelope.model_validate(payload)
+            attributes = self._validate_cloud_event_attributes(payload)
+        except (ValidationError, ValueError):
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.DROP,
+                reason="invalid_cloud_event",
+            )
+
+        expected_topic = f"{query_id}-results"
+        if envelope.topic != expected_topic or envelope.pubsubname != self._pubsub_name:
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.DROP,
+                reason="delivery_route_mismatch",
+            )
+
+        event_kind = envelope.data.get("kind")
+        try:
+            if event_kind == "change":
+                event = ChangeEvent.model_validate(envelope.data)
+                callback = self.on_change_event
+            elif event_kind == "control":
+                event = ControlEvent.model_validate(envelope.data)
+                callback = self.on_control_event
+            else:
+                return self._delivery_response(
+                    query_id=query_id,
+                    outcome=DeliveryOutcome.DROP,
+                    reason="unsupported_event_kind",
+                )
+        except ValidationError:
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.DROP,
+                reason="invalid_drasi_event",
+                event_kind=event_kind,
+            )
+
+        if event.queryId != query_id:
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.DROP,
+                reason="query_id_mismatch",
+                event_kind=event_kind,
+            )
+
+        registration = self._copy_registration(self._registrations[query_id])
+        context = CloudEventContext(
+            id=envelope.id,
+            source=envelope.source,
+            spec_version=envelope.specversion,
+            type=envelope.type,
+            topic=envelope.topic,
+            pubsub_name=envelope.pubsubname,
+            attributes=attributes,
+        )
+
+        if callback is None:
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.SUCCESS,
+                reason="no_control_handler",
+                event_kind=event_kind,
+            )
+
+        message = ReactionMessage(
+            event=event,
+            query=registration,
+            delivery=context,
+        )
+        try:
+            outcome = await callback(message)
+        except Exception:
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.RETRY,
+                reason="callback_exception",
+                event_kind=event_kind,
+            )
+
+        if outcome is None:
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.RETRY,
+                reason="callback_returned_none",
+                event_kind=event_kind,
+            )
+        if not isinstance(outcome, DeliveryOutcome):
+            return self._delivery_response(
+                query_id=query_id,
+                outcome=DeliveryOutcome.RETRY,
+                reason="invalid_callback_outcome",
+                event_kind=event_kind,
+            )
+
+        return self._delivery_response(
+            query_id=query_id,
+            outcome=outcome,
+            reason="callback_completed",
+            event_kind=event_kind,
+        )
+
+    @staticmethod
+    def _validate_cloud_event_attributes(payload: Any) -> Mapping[str, Any]:
+        if not isinstance(payload, dict):
+            raise ValueError("CloudEvent must be an object")
+
+        attributes: dict[str, Any] = {}
+        for name, value in payload.items():
+            if name == "data":
+                continue
+            if not _CLOUD_EVENT_ATTRIBUTE_NAME.fullmatch(name):
+                raise ValueError("invalid CloudEvent attribute name")
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                pass
+            elif isinstance(value, int):
+                if not _MIN_CLOUD_EVENT_INTEGER <= value <= _MAX_CLOUD_EVENT_INTEGER:
+                    raise ValueError("CloudEvent integer attribute is out of range")
+            elif isinstance(value, str):
+                if not _is_cloud_event_string(value):
+                    raise ValueError("invalid CloudEvent string attribute")
+            else:
+                raise ValueError("invalid CloudEvent attribute value")
+            attributes[name] = copy.deepcopy(value)
+
+        return MappingProxyType(attributes)
+
+    @staticmethod
+    def _delivery_path(query_id: str) -> str:
+        if "/" in query_id:
+            raise ValueError("query IDs containing '/' are not supported")
+        return f"/_drasi/events/{query_id}"
+
+    @staticmethod
+    def _copy_registration(
+        registration: QueryRegistration[ConfigT],
+    ) -> QueryRegistration[ConfigT]:
+        return QueryRegistration(
+            query_id=registration.query_id,
+            topic=registration.topic,
+            config=copy.deepcopy(registration.config),
+        )
+
+    @staticmethod
+    def _delivery_response(
+        *,
+        query_id: str,
+        outcome: DeliveryOutcome,
+        reason: str,
+        event_kind: Any = None,
+    ) -> dict[str, str]:
+        log_level = (
+            logging.INFO if outcome == DeliveryOutcome.SUCCESS else logging.WARNING
+        )
+        extra = {
+            "drasi_query_id": query_id,
+            "drasi_delivery_outcome": outcome.value,
+            "drasi_delivery_reason": reason,
+        }
+        if event_kind in ("change", "control"):
+            extra["drasi_event_kind"] = event_kind
+        logger.log(log_level, "reaction_delivery", extra=extra)
+        return {"status": outcome.value}

--- a/reactions/sdk/python/examples/advanced/Dockerfile
+++ b/reactions/sdk/python/examples/advanced/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.8-slim as builder
+FROM python:3.13.8-slim AS builder
 
 ARG POETRY_VERSION=1.8
 
@@ -12,19 +12,24 @@ ENV POETRY_CACHE_DIR=/opt/.cache
 
 RUN pip install "poetry==${POETRY_VERSION}"
 
-WORKDIR /app
+WORKDIR /sdk
 
-COPY pyproject.toml poetry.lock ./
+COPY pyproject.toml poetry.lock README.md ./
+COPY drasi ./drasi
+COPY examples/advanced/pyproject.toml examples/advanced/poetry.lock ./examples/advanced/
+
+WORKDIR /sdk/examples/advanced
 
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
-FROM python:3.13.8-slim as runtime
+FROM python:3.13.8-slim AS runtime
 
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
-COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+COPY --from=builder /sdk/examples/advanced/.venv ${VIRTUAL_ENV}
+COPY examples/advanced/main.py /app/main.py
 
-COPY . . 
+WORKDIR /app
 
-ENTRYPOINT ["python", "-m", "main"]
+ENTRYPOINT ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/reactions/sdk/python/examples/advanced/main.py
+++ b/reactions/sdk/python/examples/advanced/main.py
@@ -1,58 +1,51 @@
 import logging
 from typing import Any
 
+from fastapi import FastAPI
+
+from drasi.reaction import DeliveryOutcome, DrasiReaction, ReactionMessage
 from drasi.reaction.models.ChangeEvent import ChangeEvent
 from drasi.reaction.models.ControlEvent import ControlEvent
-from drasi.reaction.sdk import DrasiReaction
 from drasi.reaction.utils import get_config_value, yaml_query_configs
 
-logging.basicConfig(level=logging.INFO)
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("advanced_python_app")
 
+connection_string = get_config_value("MyConnectionString")
 
-def change_event_wrapper(conn_str: str):
 
-    # conn str can be accessed by the inner function
-    logger.info(f"Connection string from the config props: {conn_str}")
+async def change_event(
+    message: ReactionMessage[ChangeEvent, dict[str, Any]],
+) -> DeliveryOutcome:
+    event = message.event
+    query_config = message.query.config
 
-    async def change_event(event: ChangeEvent, query_configs: dict[Any, Any] | None):
-        logger.info(query_configs)
-        logger.info(
-            f"Received change sequence {event.sequence} for query {event.queryId}"
-        )
-
-        if event.addedResults:
-            logger.info(f"Added result: {event.addedResults}")
-
-        if event.deletedResults:
-            logger.info(f"Removed result: {event.deletedResults}")
-
-        if event.updatedResults:
-            logger.info(
-                f"Updated result - before: {event.updatedResults[0].before}, after {event.updatedResults[0].after}"
-            )
-
-    return change_event
+    logger.info(
+        "Processing change sequence %s for query %s with greeting %s",
+        event.sequence,
+        event.queryId,
+        query_config.get("greeting") if query_config else None,
+    )
+    # Use connection_string to send the result changes to the external system.
+    return DeliveryOutcome.SUCCESS
 
 
 async def control_event(
-    event: ControlEvent, query_configs: dict[Any, Any] | None = None
-):
+    message: ReactionMessage[ControlEvent, dict[str, Any]],
+) -> DeliveryOutcome:
     logger.info(
-        f"Received control signal: {event.controlSignal} for query {event.queryId}"
+        "Received control signal %s for query %s",
+        message.event.controlSignal.kind,
+        message.event.queryId,
     )
+    return DeliveryOutcome.SUCCESS
 
 
-if __name__ == "__main__":
-    conn_str = get_config_value("MyConnectionString")
-
-    change_event = change_event_wrapper(conn_str)
-
-    reaction = DrasiReaction(
-        on_change_event=change_event,
-        on_control_event=control_event,
-        parse_query_configs=yaml_query_configs,
-    )
-
-    reaction.start()
+app = FastAPI()
+reaction = DrasiReaction[dict[str, Any]](
+    on_change_event=change_event,
+    on_control_event=control_event,
+    parse_query_configs=yaml_query_configs,
+)
+reaction.install(app)

--- a/reactions/sdk/python/examples/advanced/poetry.lock
+++ b/reactions/sdk/python/examples/advanced/poetry.lock
@@ -279,14 +279,12 @@ wmi = ["wmi (>=1.5.1)"]
 
 [[package]]
 name = "drasi-reaction-sdk"
-version = "0.1.0a0"
+version = "0.2.0a0"
 description = "Reaction SDK for Project Drasi"
 optional = false
 python-versions = "<4.0,>=3.10"
-files = [
-    {file = "drasi_reaction_sdk-0.1.0a0-py3-none-any.whl", hash = "sha256:5019b4772e019f7b4719d1418b22f03d7bfe2295e25e1d40963261d562ed7642"},
-    {file = "drasi_reaction_sdk-0.1.0a0.tar.gz", hash = "sha256:64d3e42ac8e4bf573258a4a46c89f1897283cfc031b0a7084891a28145a69b37"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 dapr = ">=1.14.0,<2.0.0"
@@ -294,6 +292,11 @@ dapr-ext-fastapi = ">=1.14.0,<2.0.0"
 fastapi = {version = ">=0.115.4,<0.116.0", extras = ["standard"]}
 pydantic = ">=2.10.0,<3.0.0"
 PyYAML = "6.0.2"
+rfc3986-validator = ">=0.1.1,<0.2.0"
+
+[package.source]
+type = "directory"
+url = "../.."
 
 [[package]]
 name = "email-validator"
@@ -1326,6 +1329,17 @@ files = [
 ]
 
 [[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+description = "Pure python rfc3986 validator"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9"},
+    {file = "rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1729,4 +1743,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "6a2ee3ccbc7415f754deb67673f2a21650f1b98adac7b893b8a3472d01c951aa"
+content-hash = "62d5a817d8a6e2d3913fd2310c0498dd63ada5ef63af150938d70438ecec3080"

--- a/reactions/sdk/python/examples/advanced/pyproject.toml
+++ b/reactions/sdk/python/examples/advanced/pyproject.toml
@@ -3,11 +3,11 @@ name = "advanced"
 version = "0.1.0"
 description = "advanced drasi python reaction"
 authors = [""]
-readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-drasi-reaction-sdk = "0.1.0a0"
+drasi-reaction-sdk = {path = "../.."}
+uvicorn = "^0.32.1"
 
 
 [build-system]

--- a/reactions/sdk/python/examples/simple/Dockerfile
+++ b/reactions/sdk/python/examples/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim as builder
+FROM python:3.11-slim AS builder
 
 ARG POETRY_VERSION=1.8
 
@@ -12,19 +12,24 @@ ENV POETRY_CACHE_DIR=/opt/.cache
 
 RUN pip install "poetry==${POETRY_VERSION}"
 
-WORKDIR /app
+WORKDIR /sdk
 
-COPY pyproject.toml poetry.lock ./
+COPY pyproject.toml poetry.lock README.md ./
+COPY drasi ./drasi
+COPY examples/simple/pyproject.toml examples/simple/poetry.lock ./examples/simple/
+
+WORKDIR /sdk/examples/simple
 
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
-FROM python:3.11-slim as runtime
+FROM python:3.11-slim AS runtime
 
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
-COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+COPY --from=builder /sdk/examples/simple/.venv ${VIRTUAL_ENV}
+COPY examples/simple/main.py /app/main.py
 
-COPY . . 
+WORKDIR /app
 
-ENTRYPOINT ["python", "-m", "main"]
+ENTRYPOINT ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/reactions/sdk/python/examples/simple/main.py
+++ b/reactions/sdk/python/examples/simple/main.py
@@ -1,22 +1,27 @@
 import logging
-from typing import Any
 
+from fastapi import FastAPI
+
+from drasi.reaction import DeliveryOutcome, DrasiReaction, ReactionMessage
 from drasi.reaction.models.ChangeEvent import ChangeEvent
-from drasi.reaction.sdk import DrasiReaction
+
 
 logging.basicConfig(level=logging.INFO)
-
 logger = logging.getLogger("simple_python_app")
 
 
-async def change_event(event: ChangeEvent, query_configs: dict[Any, Any] | None = None):
-    logger.info(f"Received change sequence {event.sequence} for query {event.queryId}")
-    logger.info(event)
-
-
-if __name__ == "__main__":
-    reaction = DrasiReaction(
-        on_change_event=change_event,
+async def change_event(
+    message: ReactionMessage[ChangeEvent, None],
+) -> DeliveryOutcome:
+    event = message.event
+    logger.info(
+        "Received change sequence %s for query %s",
+        event.sequence,
+        event.queryId,
     )
+    return DeliveryOutcome.SUCCESS
 
-    reaction.start()
+
+app = FastAPI()
+reaction = DrasiReaction(on_change_event=change_event)
+reaction.install(app)

--- a/reactions/sdk/python/examples/simple/poetry.lock
+++ b/reactions/sdk/python/examples/simple/poetry.lock
@@ -279,14 +279,12 @@ wmi = ["wmi (>=1.5.1)"]
 
 [[package]]
 name = "drasi-reaction-sdk"
-version = "0.1.0a0"
+version = "0.2.0a0"
 description = "Reaction SDK for Project Drasi"
 optional = false
 python-versions = "<4.0,>=3.10"
-files = [
-    {file = "drasi_reaction_sdk-0.1.0a0-py3-none-any.whl", hash = "sha256:5019b4772e019f7b4719d1418b22f03d7bfe2295e25e1d40963261d562ed7642"},
-    {file = "drasi_reaction_sdk-0.1.0a0.tar.gz", hash = "sha256:64d3e42ac8e4bf573258a4a46c89f1897283cfc031b0a7084891a28145a69b37"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 dapr = ">=1.14.0,<2.0.0"
@@ -294,6 +292,11 @@ dapr-ext-fastapi = ">=1.14.0,<2.0.0"
 fastapi = {version = ">=0.115.4,<0.116.0", extras = ["standard"]}
 pydantic = ">=2.10.0,<3.0.0"
 PyYAML = "6.0.2"
+rfc3986-validator = ">=0.1.1,<0.2.0"
+
+[package.source]
+type = "directory"
+url = "../.."
 
 [[package]]
 name = "email-validator"
@@ -1326,6 +1329,17 @@ files = [
 ]
 
 [[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+description = "Pure python rfc3986 validator"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9"},
+    {file = "rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1729,4 +1743,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "6a2ee3ccbc7415f754deb67673f2a21650f1b98adac7b893b8a3472d01c951aa"
+content-hash = "62d5a817d8a6e2d3913fd2310c0498dd63ada5ef63af150938d70438ecec3080"

--- a/reactions/sdk/python/examples/simple/pyproject.toml
+++ b/reactions/sdk/python/examples/simple/pyproject.toml
@@ -3,11 +3,11 @@ name = "simple"
 version = "0.1.0"
 description = "simple drasi python reaction"
 authors = [""]
-readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-drasi-reaction-sdk = "0.1.0a0"
+drasi-reaction-sdk = {path = "../.."}
+uvicorn = "^0.32.1"
 
 
 [build-system]

--- a/reactions/sdk/python/examples/state-store/Dockerfile
+++ b/reactions/sdk/python/examples/state-store/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install --no-cache-dir .
 WORKDIR /app
 COPY examples/state-store/main.py .
 
-ENTRYPOINT ["python", "-m", "main"]
+ENTRYPOINT ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/reactions/sdk/python/examples/state-store/main.py
+++ b/reactions/sdk/python/examples/state-store/main.py
@@ -1,16 +1,17 @@
 import os
-from typing import Any
 
 from dapr.aio.clients import DaprClient
+from fastapi import FastAPI
+
+from drasi.reaction import DeliveryOutcome, DrasiReaction, ReactionMessage
 from drasi.reaction.models.ChangeEvent import ChangeEvent
-from drasi.reaction.sdk import DrasiReaction
 
 STATE_STORE_NAME = os.environ["StateStoreName"]
 
 
 async def on_change_event(
-    _event: ChangeEvent, _query_config: dict[str, Any] | None
-) -> None:
+    _message: ReactionMessage[ChangeEvent, None],
+) -> DeliveryOutcome:
     async with DaprClient() as client:
         current = await client.get_state(
             store_name=STATE_STORE_NAME,
@@ -24,9 +25,9 @@ async def on_change_event(
             etag=current.etag or None,
         )
 
+    return DeliveryOutcome.SUCCESS
 
+
+app = FastAPI()
 reaction = DrasiReaction(on_change_event=on_change_event)
-
-
-if __name__ == "__main__":
-    reaction.start()
+reaction.install(app)

--- a/reactions/sdk/python/poetry.lock
+++ b/reactions/sdk/python/poetry.lock
@@ -247,6 +247,17 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "certifi"
+version = "2024.8.30"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
+    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
+]
+
+[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -630,6 +641,52 @@ files = [
     {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
     {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
 ]
+
+[[package]]
+name = "httpcore"
+version = "1.0.7"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd"},
+    {file = "httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.13,<0.15"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.27.2"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
@@ -1299,6 +1356,17 @@ files = [
 ]
 
 [[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+description = "Pure python rfc3986 validator"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9"},
+    {file = "rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1488,4 +1556,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a45fff78e8b6cc0f5fa8275cc30581448edb4900d1373f8b73bfcf8af788c44b"
+content-hash = "1fdd6ad69e409beb60d4be9a2be600947159043b958c79a49aa3278c54e8462c"

--- a/reactions/sdk/python/pyproject.toml
+++ b/reactions/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drasi-reaction-sdk"
-version = "0.1.0-alpha"
+version = "0.2.0-alpha"
 description = "Reaction SDK for Project Drasi"
 license = "Apache-2.0"
 homepage = "https://drasi.io" 
@@ -17,11 +17,17 @@ dapr-ext-fastapi = "^1.14.0"
 fastapi = "^0.115.4"
 PyYAML = "6.0.2"
 pydantic = "^2.10.0"
+rfc3986-validator = "^0.1.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
 datamodel-code-generator = "0.26.3"
+httpx = "^0.27.2"
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: requires a local Dapr runtime",
+]
 
 [build-system]
 requires = ["poetry-core"]

--- a/reactions/sdk/python/tests/integration/__init__.py
+++ b/reactions/sdk/python/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Real-Dapr integration tests for the Python Reaction SDK."""

--- a/reactions/sdk/python/tests/integration/dapr_app.py
+++ b/reactions/sdk/python/tests/integration/dapr_app.py
@@ -1,0 +1,90 @@
+import asyncio
+import os
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Request
+
+from drasi.reaction import DeliveryOutcome, DrasiReaction, ReactionMessage
+from drasi.reaction.models.ChangeEvent import ChangeEvent
+
+
+app = FastAPI()
+observations: list[dict[str, Any]] = []
+delivery_counts: Counter[tuple[str, str]] = Counter()
+
+
+@app.get("/test/observations")
+async def get_observations():
+    return observations
+
+
+@app.post("/test/dead-letter")
+async def dead_letter(request: Request):
+    cloud_event = await request.json()
+    metadata = cloud_event.get("data", {}).get("metadata") or {}
+    observations.append(
+        {
+            "kind": "dead_letter",
+            "mode": metadata.get("mode"),
+            "id": cloud_event.get("id"),
+            "source": cloud_event.get("source"),
+        }
+    )
+    return {"status": "SUCCESS"}
+
+
+async def initialize() -> None:
+    gate_path = os.getenv("TEST_INITIALIZATION_GATE")
+    if gate_path is not None:
+        started = Path(f"{gate_path}.started")
+        release = Path(f"{gate_path}.release")
+        started.touch()
+        while not release.exists():
+            await asyncio.sleep(0.05)
+    observations.append({"kind": "initialized"})
+
+
+async def on_change(
+    message: ReactionMessage[ChangeEvent, None],
+) -> DeliveryOutcome:
+    identity = message.delivery.identity
+    delivery_counts[identity] += 1
+
+    metadata = message.event.metadata.root if message.event.metadata else {}
+    mode = (metadata or {}).get("mode")
+    attempt = delivery_counts[identity]
+    observations.append(
+        {
+            "kind": "delivery",
+            "mode": mode,
+            "attempt": attempt,
+            "id": message.delivery.id,
+            "source": message.delivery.source,
+            "topic": message.delivery.topic,
+            "pubsub_name": message.delivery.pubsub_name,
+            "trace_context": message.delivery.attributes.get("traceparent")
+            or message.delivery.attributes.get("traceid"),
+        }
+    )
+
+    if mode == "retry_once" and attempt == 1:
+        return DeliveryOutcome.RETRY
+    if mode == "exception_once" and attempt == 1:
+        raise RuntimeError("integration test callback failure")
+    if mode == "drop":
+        return DeliveryOutcome.DROP
+    return DeliveryOutcome.SUCCESS
+
+
+reaction_options: dict[str, Any] = {}
+if dead_letter_topic := os.getenv("TEST_DEAD_LETTER_TOPIC"):
+    reaction_options["dead_letter_topic"] = dead_letter_topic
+
+reaction = DrasiReaction(
+    on_change_event=on_change,
+    on_initialize=initialize,
+    **reaction_options,
+)
+reaction.install(app)

--- a/reactions/sdk/python/tests/integration/resources/config.yaml
+++ b/reactions/sdk/python/tests/integration/resources/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: python-reaction-sdk-test
+spec:
+  tracing:
+    samplingRate: "1"

--- a/reactions/sdk/python/tests/integration/resources/dead-letter-subscription.yaml
+++ b/reactions/sdk/python/tests/integration/resources/dead-letter-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: python-reaction-sdk-dead-letter
+spec:
+  pubsubname: drasi-pubsub
+  topic: reaction-dead-letter
+  routes:
+    default: /test/dead-letter
+scopes:
+  - python-reaction-sdk-test

--- a/reactions/sdk/python/tests/integration/resources/pubsub.yaml
+++ b/reactions/sdk/python/tests/integration/resources/pubsub.yaml
@@ -1,0 +1,8 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: drasi-pubsub
+spec:
+  type: pubsub.in-memory
+  version: v1
+  metadata: []

--- a/reactions/sdk/python/tests/integration/resources/resiliency.yaml
+++ b/reactions/sdk/python/tests/integration/resources/resiliency.yaml
@@ -1,0 +1,16 @@
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: python-reaction-sdk-retries
+spec:
+  policies:
+    retries:
+      pubsubRetry:
+        policy: constant
+        duration: 100ms
+        maxRetries: 2
+  targets:
+    components:
+      drasi-pubsub:
+        inbound:
+          retry: pubsubRetry

--- a/reactions/sdk/python/tests/integration/test_dapr_delivery.py
+++ b/reactions/sdk/python/tests/integration/test_dapr_delivery.py
@@ -1,0 +1,323 @@
+import os
+import signal
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+import httpx
+import pytest
+
+
+pytestmark = pytest.mark.integration
+APP_ID = "python-reaction-sdk-test"
+TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736"
+TRACEPARENT = f"00-{TRACE_ID}-00f067aa0ba902b7-01"
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def wait_for(
+    predicate: Callable[[], Any],
+    *,
+    timeout: float = 15,
+) -> Any:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            result = predicate()
+            if result:
+                return result
+        except (httpx.HTTPError, KeyError, ValueError) as error:
+            last_error = error
+        time.sleep(0.1)
+    raise AssertionError("condition was not met before timeout") from last_error
+
+
+def result_event(mode: str, sequence: int) -> dict[str, Any]:
+    return {
+        "kind": "change",
+        "queryId": "query1",
+        "sequence": sequence,
+        "sourceTimeMs": int(time.time() * 1000),
+        "metadata": {"mode": mode},
+        "addedResults": [{"mode": mode}],
+        "updatedResults": [],
+        "deletedResults": [],
+    }
+
+
+def stop_process_tree(process: subprocess.Popen[Any]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        process.wait(timeout=5)
+
+
+def check_runtime_requirements() -> tuple[str, str | None]:
+    if os.getenv("DAPR_INTEGRATION_TESTS") != "1":
+        pytest.skip("set DAPR_INTEGRATION_TESTS=1 to run real-Dapr tests")
+    if os.name != "posix":
+        pytest.skip("real-Dapr process isolation requires a POSIX host")
+
+    dapr = shutil.which("dapr")
+    if dapr is None:
+        pytest.fail("DAPR_INTEGRATION_TESTS=1 requires the dapr CLI on PATH")
+
+    runtime_path = os.getenv("DAPR_RUNTIME_PATH")
+    if (
+        runtime_path is not None
+        and not (Path(runtime_path) / ".dapr" / "bin" / "daprd").is_file()
+    ):
+        pytest.fail("DAPR_RUNTIME_PATH must contain .dapr/bin/daprd")
+
+    return dapr, runtime_path
+
+
+@contextmanager
+def run_dapr_runtime(
+    tmp_path_factory,
+    *,
+    app_id: str,
+    dead_letter_topic: str | None,
+) -> Iterator[dict[str, str]]:
+    dapr, runtime_path = check_runtime_requirements()
+    temp_dir = tmp_path_factory.mktemp(app_id)
+    query_dir = temp_dir / "queries"
+    query_dir.mkdir()
+    (query_dir / "query1").write_text("", encoding="utf-8")
+    initialization_gate = temp_dir / "initialization"
+
+    app_port = free_port()
+    dapr_http_port = free_port()
+    dapr_grpc_port = free_port()
+    metrics_port = free_port()
+    profile_port = free_port()
+    resources = Path(__file__).parent / "resources"
+    log_path = temp_dir / "dapr.log"
+    log_file = log_path.open("w", encoding="utf-8")
+
+    command = [dapr]
+    if runtime_path is not None:
+        command.extend(["--runtime-path", runtime_path])
+    command.extend(
+        [
+            "run",
+            "--app-id",
+            app_id,
+            "--app-port",
+            str(app_port),
+            "--dapr-http-port",
+            str(dapr_http_port),
+            "--dapr-grpc-port",
+            str(dapr_grpc_port),
+            "--metrics-port",
+            str(metrics_port),
+            "--profile-port",
+            str(profile_port),
+            "--config",
+            str(resources / "config.yaml"),
+            "--resources-path",
+            str(resources),
+            "--log-level",
+            "warn",
+            "--",
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "tests.integration.dapr_app:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(app_port),
+            "--log-level",
+            "warning",
+        ]
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "QueryConfigPath": str(query_dir),
+            "PubsubName": "drasi-pubsub",
+            "TEST_INITIALIZATION_GATE": str(initialization_gate),
+        }
+    )
+    if dead_letter_topic is not None:
+        env["TEST_DEAD_LETTER_TOPIC"] = dead_letter_topic
+    else:
+        env.pop("TEST_DEAD_LETTER_TOPIC", None)
+
+    process = subprocess.Popen(
+        command,
+        cwd=Path(__file__).parents[2],
+        env=env,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+    try:
+        try:
+            wait_for(lambda: Path(f"{initialization_gate}.started").exists())
+
+            with pytest.raises(httpx.HTTPError):
+                httpx.get(
+                    f"http://127.0.0.1:{app_port}/test/observations",
+                    timeout=0.2,
+                )
+
+            Path(f"{initialization_gate}.release").touch()
+
+            def first_app_response():
+                response = httpx.get(
+                    f"http://127.0.0.1:{app_port}/test/observations",
+                    timeout=1,
+                )
+                response.raise_for_status()
+                return {"available": True, "items": response.json()}
+
+            first_observations = wait_for(first_app_response)["items"]
+            assert {"kind": "initialized"} in first_observations
+            wait_for(
+                lambda: httpx.get(
+                    f"http://127.0.0.1:{dapr_http_port}/v1.0/healthz",
+                    timeout=1,
+                ).is_success
+            )
+        except (AssertionError, httpx.HTTPError):
+            log_file.flush()
+            pytest.fail(log_path.read_text(encoding="utf-8"))
+
+        yield {
+            "app_url": f"http://127.0.0.1:{app_port}",
+            "dapr_url": f"http://127.0.0.1:{dapr_http_port}",
+        }
+    finally:
+        stop_process_tree(process)
+        log_file.close()
+
+
+@pytest.fixture(scope="module")
+def dapr_runtime(tmp_path_factory):
+    with run_dapr_runtime(
+        tmp_path_factory,
+        app_id=APP_ID,
+        dead_letter_topic="reaction-dead-letter",
+    ) as runtime:
+        yield runtime
+
+
+@pytest.fixture(scope="module")
+def dapr_runtime_without_dlt(tmp_path_factory):
+    with run_dapr_runtime(
+        tmp_path_factory,
+        app_id="python-reaction-sdk-no-dlt-test",
+        dead_letter_topic=None,
+    ) as runtime:
+        yield runtime
+
+
+def observations(runtime: dict[str, str]) -> list[dict[str, Any]]:
+    response = httpx.get(f"{runtime['app_url']}/test/observations", timeout=2)
+    response.raise_for_status()
+    return response.json()
+
+
+def publish(runtime: dict[str, str], mode: str, sequence: int) -> None:
+    response = httpx.post(
+        f"{runtime['dapr_url']}/v1.0/publish/drasi-pubsub/query1-results",
+        json=result_event(mode, sequence),
+        headers={"traceparent": TRACEPARENT},
+        timeout=2,
+    )
+    response.raise_for_status()
+
+
+def deliveries(
+    runtime: dict[str, str],
+    mode: str,
+) -> list[dict[str, Any]]:
+    return [
+        item
+        for item in observations(runtime)
+        if item.get("kind") == "delivery" and item.get("mode") == mode
+    ]
+
+
+def wait_for_deliveries(
+    runtime: dict[str, str],
+    mode: str,
+    count: int,
+) -> list[dict[str, Any]]:
+    return wait_for(
+        lambda: (items if len(items := deliveries(runtime, mode)) >= count else None)
+    )
+
+
+def test_real_dapr_delivery_contract(dapr_runtime):
+    publish(dapr_runtime, "success", 1)
+    success = wait_for_deliveries(dapr_runtime, "success", 1)
+    assert len(success) == 1
+    assert success[0]["id"]
+    assert success[0]["source"]
+    assert success[0]["topic"] == "query1-results"
+    assert success[0]["pubsub_name"] == "drasi-pubsub"
+    assert TRACE_ID in success[0]["trace_context"]
+
+    publish(dapr_runtime, "retry_once", 2)
+    retries = wait_for_deliveries(dapr_runtime, "retry_once", 2)
+    assert [item["attempt"] for item in retries] == [1, 2]
+    assert {(item["source"], item["id"]) for item in retries} == {
+        (retries[0]["source"], retries[0]["id"])
+    }
+
+    publish(dapr_runtime, "exception_once", 3)
+    exception_retries = wait_for_deliveries(
+        dapr_runtime,
+        "exception_once",
+        2,
+    )
+    assert [item["attempt"] for item in exception_retries] == [1, 2]
+    assert {(item["source"], item["id"]) for item in exception_retries} == {
+        (exception_retries[0]["source"], exception_retries[0]["id"])
+    }
+
+    publish(dapr_runtime, "drop", 4)
+    dead_letters = wait_for(
+        lambda: [
+            item
+            for item in observations(dapr_runtime)
+            if item.get("kind") == "dead_letter" and item.get("mode") == "drop"
+        ]
+    )
+    assert len(dead_letters) == 1
+
+    time.sleep(0.75)
+    assert len(deliveries(dapr_runtime, "success")) == 1
+    assert len(deliveries(dapr_runtime, "drop")) == 1
+
+
+def test_drop_without_dlt_is_not_redelivered(dapr_runtime_without_dlt):
+    publish(dapr_runtime_without_dlt, "drop", 1)
+    wait_for_deliveries(dapr_runtime_without_dlt, "drop", 1)
+
+    time.sleep(0.75)
+    assert len(deliveries(dapr_runtime_without_dlt, "drop")) == 1

--- a/reactions/sdk/python/tests/unit/test_sdk.py
+++ b/reactions/sdk/python/tests/unit/test_sdk.py
@@ -1,54 +1,760 @@
-from pathlib import Path
-from unittest.mock import Mock
+import asyncio
+import json
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
 
 import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
 
+from drasi.reaction.delivery import DeliveryOutcome, ReactionMessage
+from drasi.reaction.models.ChangeEvent import ChangeEvent
 from drasi.reaction.sdk import DrasiReaction
 from drasi.reaction.utils import yaml_query_configs
 
-SUBSCRIBE_QUERIES = {"query1": "foo: bar", "query2": ""}
+
+def change_event(
+    query_id: str = "query1",
+    *,
+    event_id: str = "event-1",
+) -> dict[str, Any]:
+    return {
+        "id": event_id,
+        "source": "urn:drasi:test",
+        "specversion": "1.0",
+        "type": "com.dapr.event.sent",
+        "topic": f"{query_id}-results",
+        "pubsubname": "drasi-pubsub",
+        "datacontenttype": "application/json",
+        "traceid": "trace-value",
+        "data": {
+            "kind": "change",
+            "queryId": query_id,
+            "sequence": 1,
+            "sourceTimeMs": 1000,
+            "metadata": None,
+            "addedResults": [{"value": "secret-payload"}],
+            "updatedResults": [],
+            "deletedResults": [],
+        },
+    }
 
 
-@pytest.fixture(scope="session")
-def query_config_dir(tmp_path_factory):
-    mock_dir = tmp_path_factory.mktemp("queries")
+def control_event(query_id: str = "query1") -> dict[str, Any]:
+    event = change_event(query_id)
+    event["data"] = {
+        "kind": "control",
+        "queryId": query_id,
+        "sequence": 2,
+        "sourceTimeMs": 1001,
+        "metadata": None,
+        "controlSignal": {"kind": "running"},
+    }
+    return event
 
-    for query, content in SUBSCRIBE_QUERIES.items():
-        qconfig: Path = mock_dir / query
-        qconfig.write_text(content)
 
-    return mock_dir
+@pytest.fixture
+def query_config_dir(tmp_path):
+    (tmp_path / "query1").write_text("nested:\n  value: original\n", encoding="utf-8")
+    (tmp_path / "query.with.dot").write_text("enabled: true\n", encoding="utf-8")
+    return tmp_path
 
 
-def test_reaction_reads_qconfigs(query_config_dir):
-    reaction = DrasiReaction(
-        on_change_event=Mock(),
-        on_control_event=Mock(),
+def configured_reaction(
+    query_config_dir,
+    callback,
+    **kwargs,
+) -> DrasiReaction[dict[str, Any]]:
+    reaction = DrasiReaction[dict[str, Any]](
+        on_change_event=callback,
         parse_query_configs=yaml_query_configs,
+        **kwargs,
     )
     reaction._config_directory = query_config_dir
-    reaction.subscribe()
-
-    qconfigs = reaction.query_configs
-
-    for query, expected_config in SUBSCRIBE_QUERIES.items():
-        assert query in qconfigs
-        if expected_config:
-            parsed_config = yaml_query_configs(expected_config)
-            assert qconfigs[query] == parsed_config
-        else:
-            assert qconfigs[query] is None
+    return reaction
 
 
-def test_reaction_adds_routes_to_router(query_config_dir):
-    reaction = DrasiReaction(
-        on_change_event=Mock(),
-        on_control_event=Mock(),
-        parse_query_configs=yaml_query_configs,
+def test_install_composes_lifespan_and_preserves_state(query_config_dir):
+    lifecycle_events = []
+
+    @asynccontextmanager
+    async def caller_lifespan(app):
+        lifecycle_events.append("caller_start")
+        yield {"caller_resource": "available"}
+        lifecycle_events.append("caller_stop")
+
+    async def initialize():
+        lifecycle_events.append("reaction_start")
+
+    async def cleanup():
+        lifecycle_events.append("reaction_stop")
+
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI(lifespan=caller_lifespan)
+
+    @app.get("/caller")
+    async def caller_route(request: Request):
+        return {"resource": request.state.caller_resource}
+
+    reaction = configured_reaction(
+        query_config_dir,
+        callback,
+        on_initialize=initialize,
+        on_cleanup=cleanup,
     )
-    reaction._config_directory = query_config_dir
-    reaction.subscribe()
+    reaction.install(app)
 
-    routes = [route.path for route in reaction._app.router.routes]
-    for query in SUBSCRIBE_QUERIES.keys():
-        assert f"/{query}" in routes
+    assert reaction.is_ready is False
+    with TestClient(app) as client:
+        assert reaction.is_ready is True
+        assert client.get("/caller").json() == {"resource": "available"}
+        assert lifecycle_events == ["caller_start", "reaction_start"]
+
+    assert reaction.is_ready is False
+    assert lifecycle_events == [
+        "caller_start",
+        "reaction_start",
+        "reaction_stop",
+        "caller_stop",
+    ]
+
+
+def test_cleanup_runs_when_initialization_fails(query_config_dir):
+    lifecycle_events = []
+
+    @asynccontextmanager
+    async def caller_lifespan(app):
+        lifecycle_events.append("caller_start")
+        try:
+            yield
+        except RuntimeError:
+            lifecycle_events.append("caller_error")
+            raise
+        finally:
+            lifecycle_events.append("caller_stop")
+
+    async def initialize():
+        lifecycle_events.append("initialize")
+        raise RuntimeError("initialization failed")
+
+    async def cleanup():
+        lifecycle_events.append("cleanup")
+
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI(lifespan=caller_lifespan)
+    reaction = configured_reaction(
+        query_config_dir,
+        callback,
+        on_initialize=initialize,
+        on_cleanup=cleanup,
+    )
+    reaction.install(app)
+
+    with pytest.raises(RuntimeError, match="initialization failed"):
+        with TestClient(app):
+            pass
+
+    assert lifecycle_events == [
+        "caller_start",
+        "initialize",
+        "cleanup",
+        "caller_error",
+        "caller_stop",
+    ]
+    assert reaction.is_ready is False
+
+
+def test_cleanup_failure_does_not_skip_caller_teardown(query_config_dir):
+    lifecycle_events = []
+
+    @asynccontextmanager
+    async def caller_lifespan(app):
+        lifecycle_events.append("caller_start")
+        try:
+            yield
+        except RuntimeError:
+            lifecycle_events.append("caller_error")
+            raise
+        finally:
+            lifecycle_events.append("caller_stop")
+
+    async def cleanup():
+        lifecycle_events.append("cleanup")
+        raise RuntimeError("cleanup failed")
+
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI(lifespan=caller_lifespan)
+    reaction = configured_reaction(
+        query_config_dir,
+        callback,
+        on_cleanup=cleanup,
+    )
+    reaction.install(app)
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        with TestClient(app):
+            pass
+
+    assert lifecycle_events == [
+        "caller_start",
+        "cleanup",
+        "caller_error",
+        "caller_stop",
+    ]
+    assert reaction.is_ready is False
+
+
+def test_install_publishes_isolated_read_only_snapshot(query_config_dir):
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(FastAPI())
+
+    assert set(reaction.query_registrations) == {"query1", "query.with.dot"}
+    assert reaction.query_registrations["query.with.dot"].query_id == "query.with.dot"
+
+    configs = reaction.query_configs
+    with pytest.raises(TypeError):
+        configs["another"] = {}  # type: ignore[index]
+
+    configs["query1"]["nested"]["value"] = "mutated"
+    assert reaction.query_configs["query1"]["nested"]["value"] == "original"
+
+
+def test_install_without_parser_registers_none_config(query_config_dir):
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    reaction = DrasiReaction(on_change_event=callback)
+    reaction._config_directory = query_config_dir
+    reaction.install(FastAPI())
+
+    assert reaction.query_configs == {
+        "query.with.dot": None,
+        "query1": None,
+    }
+
+
+def test_parser_failure_does_not_publish_partial_state(tmp_path):
+    (tmp_path / "good").write_text("good", encoding="utf-8")
+    (tmp_path / "bad").write_text("bad", encoding="utf-8")
+
+    def parser(config_file):
+        value = config_file.read()
+        if value == "bad":
+            raise ValueError("invalid query config")
+        return value
+
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+    original_routes = tuple(app.router.routes)
+    reaction = DrasiReaction(on_change_event=callback, parse_query_configs=parser)
+    reaction._config_directory = tmp_path
+
+    with pytest.raises(ValueError, match="invalid query config"):
+        reaction.install(app)
+
+    assert reaction.query_registrations == {}
+    assert tuple(app.router.routes) == original_routes
+
+
+def test_missing_query_directory_fails_installation(tmp_path):
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+    original_routes = tuple(app.router.routes)
+    reaction = DrasiReaction(on_change_event=callback)
+    reaction._config_directory = tmp_path / "missing"
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        reaction.install(app)
+
+    assert reaction.query_registrations == {}
+    assert tuple(app.router.routes) == original_routes
+
+
+def test_empty_query_directory_publishes_empty_snapshot(tmp_path):
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+    reaction = DrasiReaction(on_change_event=callback)
+    reaction._config_directory = tmp_path
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        assert reaction.is_ready is True
+        assert client.get("/dapr/subscribe").json() == []
+
+    assert reaction.query_registrations == {}
+
+
+def test_dapr_discovery_is_readiness_gated_and_includes_dlt(query_config_dir):
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+    reaction = configured_reaction(
+        query_config_dir,
+        callback,
+        dead_letter_topic="reaction-dead-letter",
+    )
+    reaction.install(app)
+
+    client = TestClient(app)
+    assert client.get("/dapr/subscribe").status_code == 503
+    client.close()
+
+    with TestClient(app) as client:
+        response = client.get("/dapr/subscribe")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "pubsubname": "drasi-pubsub",
+            "topic": "query.with.dot-results",
+            "route": "/_drasi/events/query.with.dot",
+            "deadLetterTopic": "reaction-dead-letter",
+        },
+        {
+            "pubsubname": "drasi-pubsub",
+            "topic": "query1-results",
+            "route": "/_drasi/events/query1",
+            "deadLetterTopic": "reaction-dead-letter",
+        },
+    ]
+
+
+def test_delivery_passes_typed_event_config_and_cloud_event_context(
+    query_config_dir,
+):
+    messages: list[ReactionMessage[ChangeEvent, dict[str, Any]]] = []
+    config_values = []
+
+    async def callback(message):
+        messages.append(message)
+        config_values.append(message.query.config["nested"]["value"])
+        message.query.config["nested"]["value"] = "callback mutation"
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        first_response = client.post(
+            "/_drasi/events/query1", json=change_event(event_id="event-1")
+        )
+        second_response = client.post(
+            "/_drasi/events/query1", json=change_event(event_id="event-2")
+        )
+
+    assert first_response.json() == {"status": "SUCCESS"}
+    assert second_response.json() == {"status": "SUCCESS"}
+    assert len(messages) == 2
+    assert isinstance(messages[0].event, ChangeEvent)
+    assert messages[0].query.query_id == "query1"
+    assert messages[0].query.topic == "query1-results"
+    assert messages[0].delivery.identity == ("urn:drasi:test", "event-1")
+    assert messages[0].delivery.attributes["traceid"] == "trace-value"
+    assert "data" not in messages[0].delivery.attributes
+    assert config_values == ["original", "original"]
+    assert reaction.query_configs["query1"]["nested"]["value"] == "original"
+
+    with pytest.raises(TypeError):
+        messages[0].delivery.attributes["another"] = "value"  # type: ignore[index]
+
+
+def test_optional_cloud_event_attributes_accept_null_and_long_names(
+    query_config_dir,
+):
+    messages = []
+
+    async def callback(message):
+        messages.append(message)
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+    event = change_event()
+    event["subject"] = None
+    event["time"] = "1990-12-31t23:59:60z"
+    event["dataschema"] = "https://drasi.io/schemas/query-result"
+    event["datacontenttype"] = (
+        "application/json; profile=foo*bar; version=foo'bar; shape={query-result}"
+    )
+    event["longextensionattributename"] = "value"
+    event["attempt"] = 2**31 - 1
+    event["sampled"] = True
+
+    with TestClient(app) as client:
+        response = client.post("/_drasi/events/query1", json=event)
+
+    assert response.json() == {"status": "SUCCESS"}
+    assert messages[0].delivery.attributes["longextensionattributename"] == "value"
+    assert messages[0].delivery.attributes["time"] == "1990-12-31t23:59:60z"
+    assert messages[0].delivery.attributes["attempt"] == 2**31 - 1
+    assert messages[0].delivery.attributes["sampled"] is True
+    assert "subject" not in messages[0].delivery.attributes
+
+
+@pytest.mark.parametrize(
+    ("callback_result", "expected_status"),
+    [
+        (DeliveryOutcome.SUCCESS, "SUCCESS"),
+        (DeliveryOutcome.RETRY, "RETRY"),
+        (DeliveryOutcome.DROP, "DROP"),
+        (None, "RETRY"),
+        ("SUCCESS", "RETRY"),
+    ],
+)
+def test_callback_result_maps_to_explicit_dapr_status(
+    query_config_dir,
+    callback_result,
+    expected_status,
+):
+    async def callback(message):
+        return callback_result
+
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        response = client.post("/_drasi/events/query1", json=change_event())
+
+    assert response.json() == {"status": expected_status}
+
+
+def test_callback_exception_maps_to_retry_without_logging_sensitive_data(
+    query_config_dir,
+    caplog,
+):
+    async def callback(message):
+        raise RuntimeError("secret-exception")
+
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with caplog.at_level(logging.WARNING, logger="drasi.reaction.sdk"):
+        with TestClient(app) as client:
+            response = client.post("/_drasi/events/query1", json=change_event())
+
+    assert response.json() == {"status": "RETRY"}
+    assert caplog.records[-1].drasi_delivery_outcome == "RETRY"
+    assert caplog.records[-1].drasi_delivery_reason == "callback_exception"
+    assert "secret-exception" not in caplog.text
+    assert "secret-payload" not in caplog.text
+    assert "trace-value" not in caplog.text
+
+
+def test_callback_cancellation_propagates(query_config_dir):
+    async def callback(message):
+        raise asyncio.CancelledError()
+
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+    body = json.dumps(change_event()).encode()
+    received = False
+
+    async def receive():
+        nonlocal received
+        if received:
+            return {"type": "http.disconnect"}
+        received = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/_drasi/events/query1",
+            "raw_path": b"/_drasi/events/query1",
+            "query_string": b"",
+            "headers": [(b"content-type", b"application/json")],
+            "client": ("127.0.0.1", 1),
+            "server": ("127.0.0.1", 80),
+        },
+        receive,
+    )
+
+    with TestClient(app):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(reaction._handle_delivery("query1", request))
+
+
+def test_malformed_json_is_dropped_before_callback(query_config_dir):
+    calls = 0
+
+    async def callback(message):
+        nonlocal calls
+        calls += 1
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/_drasi/events/query1",
+            content="{",
+            headers={"content-type": "application/json"},
+        )
+
+    assert response.json() == {"status": "DROP"}
+    assert calls == 0
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda event: event.pop("id"),
+        lambda event: event.update(source="%"),
+        lambda event: event.update(source="https://exa<mple"),
+        lambda event: event.update(source="bad\u0001source"),
+        lambda event: event.update(time=123),
+        lambda event: event.update(time="not-a-timestamp"),
+        lambda event: event.update(time="2024-01-01T12:00:60Z"),
+        lambda event: event.update(time="٢٠٢٤-٠٩-٠٧T١٨:١٢:٣٢Z"),
+        lambda event: event.update(time="0001-01-01T00:00:60+23:59"),
+        lambda event: event.update(time="9999-12-31T23:59:60-23:59"),
+        lambda event: event.update(subject=True),
+        lambda event: event.update(subject=""),
+        lambda event: event.update(dataschema="relative/schema"),
+        lambda event: event.update(datacontenttype="not-a-media-type"),
+        lambda event: event.update(datacontenttype='application/json; profile="café"'),
+        lambda event: event.update(floatingextension=1.5),
+        lambda event: event.update(integerextension=2**31),
+        lambda event: event.update(stringextension="bad\u0001value"),
+        lambda event: event["data"].pop("sequence"),
+    ],
+)
+def test_malformed_event_is_dropped_before_callback(
+    query_config_dir,
+    mutate,
+):
+    calls = 0
+
+    async def callback(message):
+        nonlocal calls
+        calls += 1
+        return DeliveryOutcome.SUCCESS
+
+    payload = change_event()
+    mutate(payload)
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        response = client.post("/_drasi/events/query1", json=payload)
+
+    assert response.json() == {"status": "DROP"}
+    assert calls == 0
+
+
+def test_deeply_nested_mime_comments_do_not_escape_validation(query_config_dir):
+    calls = 0
+
+    async def callback(message):
+        nonlocal calls
+        calls += 1
+        return DeliveryOutcome.SUCCESS
+
+    payload = change_event()
+    nested_comment = "(" * 500 + "comment" + ")" * 500
+    payload["datacontenttype"] = f"application{nested_comment}/json"
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        response = client.post("/_drasi/events/query1", json=payload)
+
+    assert response.json() == {"status": "SUCCESS"}
+    assert calls == 1
+
+
+@pytest.mark.parametrize(
+    ("mutate", "path"),
+    [
+        (lambda event: event.update(topic="another-results"), "/_drasi/events/query1"),
+        (
+            lambda event: event.update(pubsubname="another-pubsub"),
+            "/_drasi/events/query1",
+        ),
+        (
+            lambda event: event["data"].update(queryId="query.with.dot"),
+            "/_drasi/events/query1",
+        ),
+        (lambda event: event["data"].update(kind="unknown"), "/_drasi/events/query1"),
+    ],
+)
+def test_invalid_delivery_is_dropped_before_callback(
+    query_config_dir,
+    mutate,
+    path,
+):
+    calls = 0
+
+    async def callback(message):
+        nonlocal calls
+        calls += 1
+        return DeliveryOutcome.SUCCESS
+
+    payload = change_event()
+    mutate(payload)
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        response = client.post(path, json=payload)
+
+    assert response.json() == {"status": "DROP"}
+    assert calls == 0
+
+
+def test_unregistered_query_is_dropped(query_config_dir):
+    async def callback(message):
+        raise AssertionError("callback must not be called")
+
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        response = client.post("/_drasi/events/unknown", json=change_event("unknown"))
+
+    assert response.json() == {"status": "DROP"}
+
+
+def test_control_event_without_handler_is_acknowledged(query_config_dir):
+    async def callback(message):
+        raise AssertionError("change callback must not be called")
+
+    app = FastAPI()
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        response = client.post("/_drasi/events/query1", json=control_event())
+
+    assert response.json() == {"status": "SUCCESS"}
+
+
+def test_control_event_callback_receives_typed_message(query_config_dir):
+    control_messages = []
+
+    async def change_callback(message):
+        raise AssertionError("change callback must not be called")
+
+    async def control_callback(message):
+        control_messages.append(message)
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+    reaction = configured_reaction(
+        query_config_dir,
+        change_callback,
+        on_control_event=control_callback,
+    )
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        response = client.post("/_drasi/events/query1", json=control_event())
+
+    assert response.json() == {"status": "SUCCESS"}
+    assert len(control_messages) == 1
+    assert control_messages[0].event.kind == "control"
+    assert control_messages[0].query.query_id == "query1"
+
+
+def test_install_preserves_fastapi_middleware(query_config_dir):
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def add_caller_header(request, call_next):
+        response = await call_next(request)
+        response.headers["x-caller-middleware"] = "preserved"
+        return response
+
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        discovery = client.get("/dapr/subscribe")
+        delivery = client.post("/_drasi/events/query1", json=change_event())
+
+    assert discovery.headers["x-caller-middleware"] == "preserved"
+    assert delivery.headers["x-caller-middleware"] == "preserved"
+
+
+def test_route_collision_fails_installation(query_config_dir):
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+
+    @app.post("/{path:path}")
+    async def catch_all(path: str):
+        return {"path": path}
+
+    reaction = configured_reaction(query_config_dir, callback)
+
+    with pytest.raises(RuntimeError, match="existing route"):
+        reaction.install(app)
+
+
+def test_same_path_with_different_method_does_not_collide(query_config_dir):
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    app = FastAPI()
+
+    @app.post("/dapr/subscribe")
+    async def caller_route():
+        return {"caller": True}
+
+    reaction = configured_reaction(query_config_dir, callback)
+    reaction.install(app)
+
+    with TestClient(app) as client:
+        assert client.get("/dapr/subscribe").status_code == 200
+        assert client.post("/dapr/subscribe").json() == {"caller": True}
+
+
+def test_reaction_and_app_cannot_be_installed_twice(query_config_dir):
+    async def callback(message):
+        return DeliveryOutcome.SUCCESS
+
+    first_app = FastAPI()
+    second_app = FastAPI()
+    first_reaction = configured_reaction(query_config_dir, callback)
+    second_reaction = configured_reaction(query_config_dir, callback)
+
+    first_reaction.install(first_app)
+    with pytest.raises(RuntimeError, match="already installed"):
+        first_reaction.install(second_app)
+    with pytest.raises(RuntimeError, match="already installed"):
+        second_reaction.install(first_app)


### PR DESCRIPTION
Closes #445

## Summary
- install the Reaction SDK into caller-owned FastAPI apps with composed startup, readiness, and cleanup
- provide atomic query registration snapshots, validated CloudEvent context, and explicit SUCCESS, RETRY, or DROP delivery outcomes
- add reaction-wide dead-letter support and payload-safe structured delivery logs
- migrate all Python examples, including state-store, to external ASGI hosting and update the state-store E2E delivery contract
- add unit, FastAPI, and real-Dapr coverage for lifecycle, validation, acknowledgement, retry, drop, dead-letter, and delivery context behavior

## Prior work

Builds on the prototype and design work in drasi-project/drasi-platform#443 by @JeffreyJPZ. Applicable implementation and tests were adapted into the generalized SDK design.

## Validation
- 50 unit and FastAPI tests passed on Python 3.10
- 2 real-Dapr 1.14.4 integration tests passed
- package and Poetry lock checks passed
- state-store Kubernetes E2E not run locally